### PR TITLE
Improve scanning efficiency and add resolved thread filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # ============================================================
-# Bugbot Autofix Configuration
+# Claude Code Bugbot Autofix Configuration
 # ============================================================
 
 # GitHub organizations to monitor (comma-separated)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidelines for AI agents working on this codebase.
 
 ## Repository Purpose
 
-This is **Bugbot Autofix**, a daemon that automatically fixes bugs reported by
+This is **Claude Code Bugbot Autofix**, a daemon that automatically fixes bugs reported by
 Cursor Bugbot on GitHub PRs using Claude Code. It does NOT detect bugs itself;
 it only reads Cursor Bugbot review comments and generates fixes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Instructions for Claude Code when working on this codebase.
 
 ## Project Overview
 
-Bugbot Autofix is a TypeScript daemon that monitors GitHub PRs for Cursor Bugbot
+Claude Code Bugbot Autofix is a TypeScript daemon that monitors GitHub PRs for Cursor Bugbot
 review comments, parses bug reports, and auto-fixes them using Claude Code
 (claude -p). Fixes are committed directly to the PR head branch.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile for Bugbot Autofix
+# Dockerfile for Claude Code Bugbot Autofix
 # Multi-stage build: installs dependencies, builds TypeScript, then
 # runs the daemon with gh CLI, claude CLI, and git available.
 # Requires mounting gh and claude auth configs as volumes.
@@ -43,7 +43,7 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/dist/ ./dist/
 
 RUN git config --global user.email "bugbot-autofix@claude-code.local" \
-  && git config --global user.name "Bugbot Autofix" \
+  && git config --global user.name "Claude Code Bugbot Autofix" \
   && git config --global credential.https://github.com.helper "!/usr/bin/gh auth git-credential"
 
 RUN mkdir -p /data/repos /data/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# Docker Compose for Bugbot Autofix
+# Docker Compose for Claude Code Bugbot Autofix
 # Persists state DB and cloned repos in a named volume.
 #
 # Authentication:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Entrypoint for Bugbot Autofix Docker container.
+# Entrypoint for Claude Code Bugbot Autofix Docker container.
 # Verifies Claude CLI authentication and onboarding state
 # before starting the daemon.
 
@@ -37,5 +37,5 @@ else
   echo "Set GH_TOKEN or mount ~/.config/gh with valid auth."
 fi
 
-echo "Starting Bugbot Autofix daemon..."
+echo "Starting Claude Code Bugbot Autofix daemon..."
 exec node dist/main.js

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bugbot-autofix",
+  "name": "claude-code-bugbot-autofix",
   "version": "0.1.0",
   "description": "Automatically fix Cursor Bugbot-reported bugs using Claude Code",
   "type": "module",

--- a/src/bugParser.ts
+++ b/src/bugParser.ts
@@ -8,7 +8,7 @@ import type { BugSeverity, BugbotBug } from "./types.js";
 import type { ReviewComment } from "./githubClient.js";
 import { logger } from "./logger.js";
 
-const BUGBOT_BUG_ID_PATTERN = /<!-- BUGBOT_BUG_ID:\s*([0-9a-f-]+)\s*-->/;
+const BUGBOT_BUG_ID_PATTERN = /<!-- BUGBOT_BUG_ID:\s*([0-9a-zA-Z_-]+)\s*-->/;
 const DESCRIPTION_PATTERN = /<!-- DESCRIPTION START -->([\s\S]*?)<!-- DESCRIPTION END -->/;
 const LOCATIONS_PATTERN = /<!-- LOCATIONS START\n([\s\S]*?)LOCATIONS END -->/;
 const TITLE_PATTERN = /^###\s+(.+)$/m;

--- a/src/bugbotMonitor.ts
+++ b/src/bugbotMonitor.ts
@@ -17,8 +17,6 @@ export class BugbotMonitor {
   private github: GitHubClient;
   private state: StateStore;
   private config: Config;
-  private lastPollTime: Date | null = null;
-
   constructor(github: GitHubClient, state: StateStore, config: Config) {
     this.github = github;
     this.state = state;
@@ -30,7 +28,6 @@ export class BugbotMonitor {
   // ============================================================
 
   async discoverUnprocessedBugs(): Promise<PrBugReport[]> {
-    const cycleStart = new Date();
     const since = this.computeSince();
 
     const repos = await this.getAllMonitoredRepos();
@@ -51,7 +48,6 @@ export class BugbotMonitor {
       }
     }
 
-    this.lastPollTime = cycleStart;
     return reports;
   }
 
@@ -208,9 +204,6 @@ export class BugbotMonitor {
   // ============================================================
 
   private computeSince(): string {
-    if (this.lastPollTime) {
-      return this.lastPollTime.toISOString();
-    }
     const lookbackMs = DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
     return new Date(Date.now() - lookbackMs).toISOString();
   }

--- a/src/bugbotMonitor.ts
+++ b/src/bugbotMonitor.ts
@@ -1,6 +1,7 @@
 // Monitor for Cursor Bugbot review comments on GitHub PRs.
-// Scans monitored repos/orgs for open PRs, fetches review comments
-// from cursor[bot], parses bug reports, and filters out already-processed bugs.
+// Uses repo-level review comment API to efficiently find cursor[bot]
+// comments without scanning every open PR individually.
+// Only PRs with unprocessed, non-resolved Bugbot comments are returned.
 // Limitations: Only detects bugs from cursor[bot] review comments
 //   with the BUGBOT_BUG_ID marker. Does not handle issue comments.
 
@@ -8,12 +9,15 @@ import { isBugbotComment, parseBugbotComment } from "./bugParser.js";
 import type { GitHubClient } from "./githubClient.js";
 import { logger } from "./logger.js";
 import type { StateStore } from "./state.js";
-import type { Config, PrBugReport, PullRequest } from "./types.js";
+import type { Config, PrBugReport } from "./types.js";
+
+const DEFAULT_LOOKBACK_DAYS = 7;
 
 export class BugbotMonitor {
   private github: GitHubClient;
   private state: StateStore;
   private config: Config;
+  private lastPollTime: Date | null = null;
 
   constructor(github: GitHubClient, state: StateStore, config: Config) {
     this.github = github;
@@ -22,26 +26,72 @@ export class BugbotMonitor {
   }
 
   // ============================================================
-  // Main: Discover unprocessed Bugbot bugs across all monitored PRs
+  // Main: Discover unprocessed Bugbot bugs across all monitored repos
   // ============================================================
 
   async discoverUnprocessedBugs(): Promise<PrBugReport[]> {
-    const allPrs = await this.getAllMonitoredPrs();
-    logger.info(`Found ${allPrs.length} open PR(s) across monitored repos.`);
+    const cycleStart = new Date();
+    const since = this.computeSince();
+
+    const repos = await this.getAllMonitoredRepos();
+    logger.info(`Scanning ${repos.length} repo(s) for cursor[bot] comments since ${since}.`);
 
     const reports: PrBugReport[] = [];
 
-    for (const pr of allPrs) {
+    for (const { owner, repo } of repos) {
       try {
-        const report = await this.scanPrForBugs(pr);
+        const repoReports = await this.scanRepoForBugs(owner, repo, since);
+        reports.push(...repoReports);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(`Error scanning repo ${owner}/${repo}.`, {
+          error: message,
+          repo: `${owner}/${repo}`,
+        });
+      }
+    }
+
+    this.lastPollTime = cycleStart;
+    return reports;
+  }
+
+  // ============================================================
+  // Scan a single repo for Bugbot bugs (repo-level comment fetch)
+  // ============================================================
+
+  private async scanRepoForBugs(
+    owner: string,
+    repo: string,
+    since: string
+  ): Promise<PrBugReport[]> {
+    const commentsByPr = await this.github.listRepoBugbotComments(
+      owner,
+      repo,
+      since
+    );
+
+    if (commentsByPr.size === 0) {
+      return [];
+    }
+
+    const reports: PrBugReport[] = [];
+
+    for (const [prNumber, comments] of commentsByPr) {
+      try {
+        const report = await this.processPrComments(
+          owner,
+          repo,
+          prNumber,
+          comments
+        );
         if (report && report.bugs.length > 0) {
           reports.push(report);
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         logger.error(
-          `Error scanning PR #${pr.number} in ${pr.owner}/${pr.repo}.`,
-          { error: message, prNumber: pr.number, repo: `${pr.owner}/${pr.repo}` }
+          `Error processing comments for PR #${prNumber} in ${owner}/${repo}.`,
+          { error: message, prNumber, repo: `${owner}/${repo}` }
         );
       }
     }
@@ -50,35 +100,41 @@ export class BugbotMonitor {
   }
 
   // ============================================================
-  // Scan a single PR for Bugbot bugs
+  // Process cursor[bot] comments for a single PR
   // ============================================================
 
-  private async scanPrForBugs(pr: PullRequest): Promise<PrBugReport | null> {
-    const comments = await this.github.listReviewComments(
-      pr.owner,
-      pr.repo,
-      pr.number
-    );
-
+  private async processPrComments(
+    owner: string,
+    repo: string,
+    prNumber: number,
+    comments: import("./githubClient.js").ReviewComment[]
+  ): Promise<PrBugReport | null> {
     const bugbotComments = comments.filter(isBugbotComment);
-
     if (bugbotComments.length === 0) {
       return null;
     }
 
-    logger.debug(
-      `Found ${bugbotComments.length} Bugbot comment(s) on PR #${pr.number}.`,
-      { owner: pr.owner, repo: pr.repo, prNumber: pr.number }
+    const resolvedIds = await this.github.getResolvedCommentIds(
+      owner,
+      repo,
+      prNumber
     );
 
     const unprocessedBugs = [];
 
     for (const comment of bugbotComments) {
+      if (resolvedIds.has(comment.id)) {
+        logger.debug("Bug comment resolved, skipping.", {
+          commentId: comment.id,
+        });
+        continue;
+      }
+
       const bug = parseBugbotComment(comment);
       if (!bug) continue;
 
       if (this.state.isBugProcessed(bug.bugId)) {
-        logger.debug(`Bug already processed, skipping.`, { bugId: bug.bugId });
+        logger.debug("Bug already processed, skipping.", { bugId: bug.bugId });
         continue;
       }
 
@@ -89,11 +145,16 @@ export class BugbotMonitor {
       return null;
     }
 
+    const pr = await this.github.getPullRequest(owner, repo, prNumber);
+    if (!pr) {
+      return null;
+    }
+
     logger.info(
-      `PR #${pr.number} in ${pr.owner}/${pr.repo}: ${unprocessedBugs.length} unprocessed bug(s) found.`,
+      `PR #${prNumber} in ${owner}/${repo}: ${unprocessedBugs.length} unprocessed bug(s) found.`,
       {
-        prNumber: pr.number,
-        repo: `${pr.owner}/${pr.repo}`,
+        prNumber,
+        repo: `${owner}/${repo}`,
         bugCount: unprocessedBugs.length,
         bugIds: unprocessedBugs.map((b) => b.bugId),
       }
@@ -103,11 +164,13 @@ export class BugbotMonitor {
   }
 
   // ============================================================
-  // List all open PRs across monitored repos and orgs
+  // List all monitored repos from config
   // ============================================================
 
-  private async getAllMonitoredPrs(): Promise<PullRequest[]> {
-    const allPrs: PullRequest[] = [];
+  private async getAllMonitoredRepos(): Promise<
+    Array<{ owner: string; repo: string }>
+  > {
+    const allRepos: Array<{ owner: string; repo: string }> = [];
     const processedRepos = new Set<string>();
 
     for (const repoSpec of this.config.githubRepos) {
@@ -116,16 +179,7 @@ export class BugbotMonitor {
       const repoKey = `${owner}/${repo}`;
       if (processedRepos.has(repoKey)) continue;
       processedRepos.add(repoKey);
-
-      try {
-        const prs = await this.github.listOpenPullRequests(owner, repo);
-        allPrs.push(...prs);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        logger.error(`Failed to list PRs for ${repoKey}.`, {
-          error: message, repo: repoKey,
-        });
-      }
+      allRepos.push({ owner, repo });
     }
 
     for (const org of this.config.githubOrgs) {
@@ -135,28 +189,29 @@ export class BugbotMonitor {
           const repoKey = `${repo.owner}/${repo.name}`;
           if (processedRepos.has(repoKey)) continue;
           processedRepos.add(repoKey);
-
-          try {
-            const prs = await this.github.listOpenPullRequests(
-              repo.owner,
-              repo.name
-            );
-            allPrs.push(...prs);
-          } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            logger.error(`Failed to list PRs for ${repoKey}.`, {
-              error: message, repo: repoKey,
-            });
-          }
+          allRepos.push({ owner: repo.owner, repo: repo.name });
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         logger.error(`Failed to list repos for org "${org}".`, {
-          error: message, org,
+          error: message,
+          org,
         });
       }
     }
 
-    return allPrs;
+    return allRepos;
+  }
+
+  // ============================================================
+  // Compute the "since" timestamp for the API query
+  // ============================================================
+
+  private computeSince(): string {
+    if (this.lastPollTime) {
+      return this.lastPollTime.toISOString();
+    }
+    const lookbackMs = DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+    return new Date(Date.now() - lookbackMs).toISOString();
   }
 }

--- a/src/bugbotMonitor.ts
+++ b/src/bugbotMonitor.ts
@@ -143,6 +143,20 @@ export class BugbotMonitor {
 
     const pr = await this.github.getPullRequest(owner, repo, prNumber);
     if (!pr) {
+      // PR is closed/inaccessible — mark bugs as permanently skipped so
+      // stale FAILED records don't disable the time filter in computeSince().
+      this.state.recordProcessedBugs(
+        unprocessedBugs.map((b) => ({
+          bugId: b.bugId,
+          repo: `${owner}/${repo}`,
+          prNumber,
+        })),
+        "SKIPPED_PR_CLOSED"
+      );
+      logger.debug(
+        `PR #${prNumber} in ${owner}/${repo} is closed/inaccessible, skipping ${unprocessedBugs.length} bug(s).`,
+        { prNumber, repo: `${owner}/${repo}`, bugIds: unprocessedBugs.map((b) => b.bugId) }
+      );
       return null;
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-// Configuration loader for Bugbot Autofix.
+// Configuration loader for Claude Code Bugbot Autofix.
 // Reads environment variables (with dotenv support) and validates
 // required settings. Provides sensible defaults for optional values.
 // Limitations: Only supports environment variable configuration,

--- a/src/fixGenerator.ts
+++ b/src/fixGenerator.ts
@@ -1,4 +1,4 @@
-// Fix generation module for Bugbot Autofix.
+// Fix generation module for Claude Code Bugbot Autofix.
 // Clones the target repository locally, checks out the PR head branch,
 // runs claude -p with edit tools to fix detected Cursor Bugbot bugs,
 // then commits and pushes the fix directly to the PR head branch.
@@ -232,7 +232,7 @@ export class FixGenerator {
     await this.execGit(repoDir, ["add", "-A"]);
 
     const bugTitles = bugs.map((b) => `- ${b.title}`).join("\n");
-    const commitMessage = `fix: Bugbot Autofix\n\nFixed Cursor Bugbot issues:\n${bugTitles}`;
+    const commitMessage = `fix: Claude Code Bugbot Autofix\n\nFixed Cursor Bugbot issues:\n${bugTitles}`;
 
     await this.execGit(repoDir, ["commit", "-m", commitMessage]);
 

--- a/src/fixGenerator.ts
+++ b/src/fixGenerator.ts
@@ -73,7 +73,7 @@ export class FixGenerator {
         branch: pr.headRef,
         error: message,
       });
-      return null;
+      throw error;
     }
   }
 

--- a/src/githubClient.ts
+++ b/src/githubClient.ts
@@ -103,23 +103,6 @@ export class GitHubClient {
 
     try {
       for await (const response of this.octokit.paginate.iterator(
-        this.octokit.rest.repos.listForUser,
-        { username: owner, per_page: 100, type: "owner" }
-      )) {
-        for (const repo of response.data) {
-          repos.push({ owner, name: repo.name });
-        }
-      }
-      logger.debug(`Found ${repos.length} repo(s) for user "${owner}".`);
-      return repos;
-    } catch (userError) {
-      logger.debug(`Failed to list repos as user "${owner}", trying as org...`, {
-        error: userError instanceof Error ? userError.message : String(userError),
-      });
-    }
-
-    try {
-      for await (const response of this.octokit.paginate.iterator(
         this.octokit.rest.repos.listForOrg,
         { org: owner, per_page: 100, type: "all" }
       )) {
@@ -128,9 +111,26 @@ export class GitHubClient {
         }
       }
       logger.debug(`Found ${repos.length} repo(s) for org "${owner}".`);
+      return repos;
     } catch (orgError) {
-      logger.error(`Failed to list repos for "${owner}" as both user and org.`, {
+      logger.debug(`Failed to list repos as org "${owner}", trying as user...`, {
         error: orgError instanceof Error ? orgError.message : String(orgError),
+      });
+    }
+
+    try {
+      for await (const response of this.octokit.paginate.iterator(
+        this.octokit.rest.repos.listForUser,
+        { username: owner, per_page: 100, type: "owner" }
+      )) {
+        for (const repo of response.data) {
+          repos.push({ owner, name: repo.name });
+        }
+      }
+      logger.debug(`Found ${repos.length} repo(s) for user "${owner}".`);
+    } catch (userError) {
+      logger.error(`Failed to list repos for "${owner}" as both org and user.`, {
+        error: userError instanceof Error ? userError.message : String(userError),
       });
     }
 
@@ -138,24 +138,40 @@ export class GitHubClient {
   }
 
   // ============================================================
-  // Review Comments (for reading Cursor Bugbot reports)
+  // Review Comments (repo-level, filtered for cursor[bot])
   // ============================================================
 
-  async listReviewComments(
+  async listRepoBugbotComments(
     owner: string,
     repo: string,
-    prNumber: number
-  ): Promise<ReviewComment[]> {
-    logger.debug("Fetching PR review comments.", { owner, repo, prNumber });
+    since?: string
+  ): Promise<Map<number, ReviewComment[]>> {
+    logger.debug("Fetching repo-level cursor[bot] review comments.", {
+      owner,
+      repo,
+      since: since ?? "(all)",
+    });
 
-    const comments: ReviewComment[] = [];
+    const commentsByPr = new Map<number, ReviewComment[]>();
 
     for await (const response of this.octokit.paginate.iterator(
-      this.octokit.rest.pulls.listReviewComments,
-      { owner, repo, pull_number: prNumber, per_page: 100 }
+      this.octokit.rest.pulls.listReviewCommentsForRepo,
+      {
+        owner,
+        repo,
+        sort: "created",
+        direction: "desc",
+        since,
+        per_page: 100,
+      }
     )) {
       for (const comment of response.data) {
-        comments.push({
+        if (comment.user?.login !== "cursor[bot]") continue;
+
+        const prNumber = extractPrNumberFromUrl(comment.pull_request_url);
+        if (!prNumber) continue;
+
+        const rc: ReviewComment = {
           id: comment.id,
           body: comment.body,
           path: comment.path,
@@ -165,11 +181,129 @@ export class GitHubClient {
           userLogin: comment.user.login,
           pullRequestReviewId: comment.pull_request_review_id ?? 0,
           createdAt: comment.created_at,
-        });
+        };
+
+        const existing = commentsByPr.get(prNumber) ?? [];
+        existing.push(rc);
+        commentsByPr.set(prNumber, existing);
       }
     }
 
-    return comments;
+    if (commentsByPr.size > 0) {
+      logger.debug(
+        `Found cursor[bot] comments on ${commentsByPr.size} PR(s) in ${owner}/${repo}.`
+      );
+    }
+
+    return commentsByPr;
+  }
+
+  // ============================================================
+  // Single Pull Request (for fetching details of affected PRs)
+  // ============================================================
+
+  async getPullRequest(
+    owner: string,
+    repo: string,
+    prNumber: number
+  ): Promise<PullRequest | null> {
+    logger.debug("Fetching PR details.", { owner, repo, prNumber });
+
+    const { data: pr } = await this.octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+
+    if (pr.state !== "open") {
+      logger.debug(`PR #${prNumber} is ${pr.state}, skipping.`, {
+        owner,
+        repo,
+        prNumber,
+      });
+      return null;
+    }
+
+    return {
+      owner,
+      repo,
+      number: pr.number,
+      title: pr.title,
+      headRef: pr.head.ref,
+      baseRef: pr.base.ref,
+      headSha: pr.head.sha,
+      htmlUrl: pr.html_url,
+    };
+  }
+
+  // ============================================================
+  // Resolved review threads (via GraphQL)
+  // ============================================================
+
+  async getResolvedCommentIds(
+    owner: string,
+    repo: string,
+    prNumber: number
+  ): Promise<Set<number>> {
+    logger.debug("Fetching resolved review threads via GraphQL.", {
+      owner,
+      repo,
+      prNumber,
+    });
+
+    const resolvedIds = new Set<number>();
+    let hasNextPage = true;
+    let cursor: string | null = null;
+
+    while (hasNextPage) {
+      const afterClause = cursor ? `, after: "${cursor}"` : "";
+      const query = `
+        query {
+          repository(owner: "${owner}", name: "${repo}") {
+            pullRequest(number: ${prNumber}) {
+              reviewThreads(first: 100${afterClause}) {
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+                nodes {
+                  isResolved
+                  comments(first: 1) {
+                    nodes {
+                      databaseId
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `;
+
+      const response: GraphQLReviewThreadsResponse =
+        await this.octokit.graphql(query);
+
+      const threads =
+        response.repository.pullRequest.reviewThreads;
+
+      for (const thread of threads.nodes) {
+        if (thread.isResolved && thread.comments.nodes.length > 0) {
+          resolvedIds.add(thread.comments.nodes[0].databaseId);
+        }
+      }
+
+      hasNextPage = threads.pageInfo.hasNextPage;
+      cursor = threads.pageInfo.endCursor;
+    }
+
+    if (resolvedIds.size > 0) {
+      logger.debug(
+        `Found ${resolvedIds.size} resolved review thread(s).`,
+        { owner, repo, prNumber }
+      );
+    }
+
+    return resolvedIds;
   }
 
   // ============================================================
@@ -198,6 +332,32 @@ export class GitHubClient {
 // ============================================================
 // Token validation utility
 // ============================================================
+
+interface GraphQLReviewThreadsResponse {
+  repository: {
+    pullRequest: {
+      reviewThreads: {
+        pageInfo: {
+          hasNextPage: boolean;
+          endCursor: string | null;
+        };
+        nodes: Array<{
+          isResolved: boolean;
+          comments: {
+            nodes: Array<{
+              databaseId: number;
+            }>;
+          };
+        }>;
+      };
+    };
+  };
+}
+
+function extractPrNumberFromUrl(url: string): number | null {
+  const match = url.match(/\/pulls\/(\d+)$/);
+  return match ? parseInt(match[1], 10) : null;
+}
 
 function validateGitHubToken(token: string): void {
   const validPrefixes = ["ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_"];

--- a/src/githubClient.ts
+++ b/src/githubClient.ts
@@ -63,37 +63,6 @@ export class GitHubClient {
     }
   }
 
-  // ============================================================
-  // Pull Requests
-  // ============================================================
-
-  async listOpenPullRequests(
-    owner: string,
-    repo: string
-  ): Promise<PullRequest[]> {
-    logger.debug("Listing open PRs.", { owner, repo });
-
-    const { data } = await this.octokit.rest.pulls.list({
-      owner,
-      repo,
-      state: "open",
-      sort: "updated",
-      direction: "desc",
-      per_page: 100,
-    });
-
-    return data.map((pr) => ({
-      owner,
-      repo,
-      number: pr.number,
-      title: pr.title,
-      headRef: pr.head.ref,
-      baseRef: pr.base.ref,
-      headSha: pr.head.sha,
-      htmlUrl: pr.html_url,
-    }));
-  }
-
   async listOwnerRepos(
     owner: string
   ): Promise<Array<{ owner: string; name: string }>> {

--- a/src/githubClient.ts
+++ b/src/githubClient.ts
@@ -225,12 +225,11 @@ export class GitHubClient {
     let cursor: string | null = null;
 
     while (hasNextPage) {
-      const afterClause = cursor ? `, after: "${cursor}"` : "";
       const query = `
-        query {
-          repository(owner: "${owner}", name: "${repo}") {
-            pullRequest(number: ${prNumber}) {
-              reviewThreads(first: 100${afterClause}) {
+        query($owner: String!, $repo: String!, $prNumber: Int!, $after: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $prNumber) {
+              reviewThreads(first: 100, after: $after) {
                 pageInfo {
                   hasNextPage
                   endCursor
@@ -250,7 +249,12 @@ export class GitHubClient {
       `;
 
       const response: GraphQLReviewThreadsResponse =
-        await this.octokit.graphql(query);
+        await this.octokit.graphql(query, {
+          owner,
+          repo,
+          prNumber,
+          after: cursor,
+        });
 
       const pullRequest = response.repository.pullRequest;
       if (!pullRequest) {

--- a/src/githubClient.ts
+++ b/src/githubClient.ts
@@ -1,4 +1,4 @@
-// GitHub API client for Bugbot Autofix.
+// GitHub API client for Claude Code Bugbot Autofix.
 // Wraps Octokit to provide typed operations for monitoring
 // Cursor Bugbot review comments and managing PRs.
 // Uses gh CLI auth token or GH_TOKEN for authentication.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-// Simple structured logger for Bugbot Autofix.
+// Simple structured logger for Claude Code Bugbot Autofix.
 // Supports log levels (debug, info, warn, error) with
 // timestamped messages to stdout/stderr.
 // Limitations: No file-based logging or log rotation.

--- a/src/main.ts
+++ b/src/main.ts
@@ -342,10 +342,17 @@ function acquireLock(dbPath: string): string {
       }
 
       // Stale lock file from a crashed process — reclaim it
-      unlinkSync(lockPath);
-      const fd = openSync(lockPath, "wx");
-      writeFileSync(fd, String(process.pid));
-      closeSync(fd);
+      try {
+        unlinkSync(lockPath);
+        const fd = openSync(lockPath, "wx");
+        writeFileSync(fd, String(process.pid));
+        closeSync(fd);
+      } catch {
+        throw new Error(
+          `Another daemon instance is already running (lock: ${lockPath}). ` +
+            "Stop the existing instance first."
+        );
+      }
       return lockPath;
     }
     throw error;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-// Main entry point for Bugbot Autofix daemon.
+// Main entry point for Claude Code Bugbot Autofix daemon.
 // Orchestrates the polling loop: discovers Cursor Bugbot reports
 // on open PRs, generates fixes using Claude Code, and commits
 // the fixes directly to the PR head branch.
@@ -37,7 +37,7 @@ class AutofixDaemon {
   // ============================================================
 
   async initialize(): Promise<void> {
-    logger.info("Initializing Bugbot Autofix...");
+    logger.info("Initializing Claude Code Bugbot Autofix...");
     logger.info("Configuration loaded.", {
       orgs: this.config.githubOrgs,
       repos: this.config.githubRepos,
@@ -243,7 +243,7 @@ class AutofixDaemon {
 
     const body =
       `${AUTOFIX_COMMENT_MARKER}\n` +
-      `[Bugbot Autofix](https://github.com/Senna46/claude-code-bugbot-autofix) committed fixes to address ` +
+      `[Claude Code Bugbot Autofix](https://github.com/Senna46/claude-code-bugbot-autofix) committed fixes to address ` +
       `${fixResult.fixedBugs.length} Cursor Bugbot issue(s) ([${commitShort}](${commitUrl})).\n\n` +
       `**Fixed issues:**\n${fixedList}`;
 
@@ -284,7 +284,7 @@ class AutofixDaemon {
 
   private shutdown(): void {
     this.state.close();
-    logger.info("Bugbot Autofix stopped.");
+    logger.info("Claude Code Bugbot Autofix stopped.");
   }
 
   private sleep(ms: number): Promise<void> {

--- a/src/state.ts
+++ b/src/state.ts
@@ -63,6 +63,15 @@ export class StateStore {
     return row !== undefined;
   }
 
+  hasFailedBugsForRepo(repo: string): boolean {
+    const row = this.db
+      .prepare(
+        "SELECT 1 FROM processed_bugs WHERE fix_commit_sha = 'FAILED' AND repo = ? LIMIT 1"
+      )
+      .get(repo);
+    return row !== undefined;
+  }
+
   recordProcessedBug(
     bugId: string,
     repo: string,

--- a/src/state.ts
+++ b/src/state.ts
@@ -54,15 +54,6 @@ export class StateStore {
     return row !== undefined && row.fix_commit_sha !== "FAILED";
   }
 
-  hasFailedBugs(): boolean {
-    const row = this.db
-      .prepare(
-        "SELECT 1 FROM processed_bugs WHERE fix_commit_sha = 'FAILED' LIMIT 1"
-      )
-      .get();
-    return row !== undefined;
-  }
-
   hasFailedBugsForRepo(repo: string): boolean {
     const row = this.db
       .prepare(

--- a/src/state.ts
+++ b/src/state.ts
@@ -48,8 +48,18 @@ export class StateStore {
 
   isBugProcessed(bugId: string): boolean {
     const row = this.db
-      .prepare("SELECT 1 FROM processed_bugs WHERE bug_id = ?")
-      .get(bugId);
+      .prepare("SELECT fix_commit_sha FROM processed_bugs WHERE bug_id = ?")
+      .get(bugId) as { fix_commit_sha: string | null } | undefined;
+    // Bugs marked as FAILED should be retried
+    return row !== undefined && row.fix_commit_sha !== "FAILED";
+  }
+
+  hasFailedBugs(): boolean {
+    const row = this.db
+      .prepare(
+        "SELECT 1 FROM processed_bugs WHERE fix_commit_sha = 'FAILED' LIMIT 1"
+      )
+      .get();
     return row !== undefined;
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,4 @@
-// SQLite-based state management for Bugbot Autofix.
+// SQLite-based state management for Claude Code Bugbot Autofix.
 // Tracks which Cursor Bugbot bug IDs have been processed
 // to prevent duplicate fix attempts.
 // Limitations: Single-process only; no concurrent access support.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-// Data models and type definitions for Bugbot Autofix.
+// Data models and type definitions for Claude Code Bugbot Autofix.
 // Defines shared interfaces for configuration, parsed Cursor Bugbot
 // bug reports, fix results, and PR metadata.
 // Limitations: BugbotBug fields depend on the Cursor Bugbot comment


### PR DESCRIPTION
## Summary

- **Efficient repo-level scanning**: Replaced per-PR comment fetching with `pulls.listReviewCommentsForRepo` API, dramatically reducing API calls by fetching all `cursor[bot]` comments at the repo level and grouping by PR client-side.
- **Resolved thread filtering**: Added GraphQL-based detection of resolved review threads. Bugs whose threads have been manually resolved are now skipped, preventing unwanted fixes.
- **Single-instance lock**: Added file-based lock (`daemon.lock`) to prevent multiple daemon instances from running concurrently.
- **Bug fixes**: Fixed bug ID regex to support alphanumeric prefixes (e.g. `ref1_...`), and changed error handling so failed fix attempts are retried in the next polling cycle instead of being marked as processed.
- **Project rename**: Package name updated to `claude-code-bugbot-autofix` to match the GitHub repository.
- **README overhaul**: Updated architecture diagram to reflect new scanning flow, added macOS `launchd` service instructions, and documented all new features.

## Changed files

| File | Change |
|------|--------|
| `src/githubClient.ts` | Add `listRepoBugbotComments`, `getPullRequest`, `getResolvedCommentIds` (GraphQL); prioritize `listForOrg` over `listForUser` |
| `src/bugbotMonitor.ts` | Rewrite to use repo-level scanning, `since` timestamp, resolved thread filtering |
| `src/main.ts` | Add single-instance file lock; improve error handling for retries |
| `src/bugParser.ts` | Expand bug ID regex to support alphanumeric characters |
| `src/fixGenerator.ts` | Re-throw errors instead of returning null |
| `package.json` | Rename to `claude-code-bugbot-autofix` |
| `README.md` | Update features, architecture diagram, add macOS launchd section |

## Test plan

- [ ] `npm run typecheck` passes with zero errors
- [ ] `npm run build` succeeds
- [ ] Daemon starts and scans repos without errors
- [ ] Resolved review threads are correctly skipped
- [ ] Single-instance lock prevents duplicate daemons


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core polling/monitoring and GitHub API interactions (REST+GraphQL) plus state semantics for retries/skips, which could change what gets processed or retried if edge cases are missed.
> 
> **Overview**
> Refactors Bugbot discovery to **scan repo-level `cursor[bot]` review comments** (with a `since` lookback) and then **group/process by PR**, instead of iterating every open PR; this includes a REST check to skip closed/inaccessible PRs and a GraphQL pass to **ignore resolved review threads**, recording terminal skip states.
> 
> Changes failure semantics so fix attempts that error are recorded as `FAILED` and **retried in later cycles** (and disables the `since` filter for repos with failures), adds a **file-based single-instance lock** (`daemon.lock`), and expands Bugbot ID parsing to accept non-UUID IDs. Fix generation now includes **PR diff + changed-file contents** in the Claude prompt and rethrows errors so the daemon can mark failures consistently.
> 
> Also renames the project/package and updates Docker/git identity strings and README/docs to “Claude Code Bugbot Autofix” (including new macOS `launchd` service instructions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06009cb02de7dabdeb288397fc6a6490475f8b6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->