### PR TITLE
feat: improve fix quality with expanded context and better output format

### DIFF
--- a/src/fixGenerator.ts
+++ b/src/fixGenerator.ts
@@ -2,7 +2,8 @@
 // Clones the target repository locally, checks out the PR head branch,
 // runs claude -p with edit and exploration tools to fix detected Cursor Bugbot bugs,
 // then commits and pushes the fix directly to the PR head branch.
-// Includes PR diff and changed file contents as context for better fixes.
+// Includes project structure, documentation, PR diff, changed file contents,
+// and related file imports as context for accurate, well-integrated fixes.
 // Limitations: Requires git CLI with push access to the target repo.
 //   Claude may not fix all bugs or may introduce new issues.
 //   Only one fix generation runs at a time per PR.
@@ -11,7 +12,7 @@ import { execFile, spawn } from "child_process";
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { mkdir } from "fs/promises";
-import { join } from "path";
+import { dirname, join } from "path";
 import { promisify } from "util";
 
 import { logger } from "./logger.js";
@@ -19,6 +20,11 @@ import type { BugbotBug, Config, FixResult, PullRequest } from "./types.js";
 
 const MAX_DIFF_SIZE = 100_000;
 const MAX_FILE_CONTEXT_SIZE = 200_000;
+const MAX_RELATED_CONTEXT_SIZE = 100_000;
+const MAX_PROJECT_STRUCTURE_SIZE = 5_000;
+const MAX_DOC_SIZE = 10_000;
+
+const PROJECT_DOC_FILES = ["CLAUDE.md", "AGENTS.md", "README.md"];
 
 const ALLOWED_TOOLS = [
   "Read",
@@ -68,11 +74,21 @@ export class FixGenerator {
         repoDir,
         prDiff
       );
+      const projectStructure = await this.getProjectStructure(repoDir);
+      const projectDocs = await this.getProjectDocumentation(repoDir);
+      const relatedFileContents = await this.getRelatedFileContents(
+        repoDir,
+        bugs,
+        new Set(changedFileContents.keys())
+      );
 
       const prompt = this.buildFixPrompt(
         bugs,
         prDiff,
-        changedFileContents
+        changedFileContents,
+        projectStructure,
+        projectDocs,
+        relatedFileContents
       );
 
       await this.runClaudeFix(repoDir, prompt, bugs.length);
@@ -176,13 +192,26 @@ export class FixGenerator {
   private buildFixPrompt(
     bugs: BugbotBug[],
     prDiff: string,
-    changedFileContents: Map<string, string>
+    changedFileContents: Map<string, string>,
+    projectStructure: string,
+    projectDocs: string,
+    relatedFileContents: Map<string, string>
   ): string {
     const sections: string[] = [];
 
     sections.push(
       "You are fixing bugs reported by Cursor Bugbot in this codebase."
     );
+
+    if (projectStructure) {
+      sections.push(
+        `## Project structure\n\n\`\`\`\n${projectStructure}\n\`\`\``
+      );
+    }
+
+    if (projectDocs) {
+      sections.push(`## Project documentation\n\n${projectDocs}`);
+    }
 
     const bugDescriptions = bugs
       .map(
@@ -210,6 +239,15 @@ export class FixGenerator {
         .join("\n\n");
       sections.push(
         `## Current contents of changed files\n\n${entries}`
+      );
+    }
+
+    if (relatedFileContents.size > 0) {
+      const entries = [...relatedFileContents.entries()]
+        .map(([path, content]) => `--- ${path} ---\n${content}`)
+        .join("\n\n");
+      sections.push(
+        `## Related files (dependencies of bug files)\n\n${entries}`
       );
     }
 
@@ -287,6 +325,206 @@ export class FixGenerator {
       child.stdin.write(prompt);
       child.stdin.end();
     });
+  }
+
+  // ============================================================
+  // Project structure and documentation context
+  // ============================================================
+
+  private async getProjectStructure(repoDir: string): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync(
+        "tree",
+        [
+          "-L",
+          "3",
+          "-I",
+          "node_modules|.git|dist|build|__pycache__|.next|venv|.venv",
+        ],
+        { cwd: repoDir, timeout: 10_000, maxBuffer: 1024 * 1024 }
+      );
+      if (stdout.length > MAX_PROJECT_STRUCTURE_SIZE) {
+        return (
+          stdout.substring(0, MAX_PROJECT_STRUCTURE_SIZE) +
+          "\n... (truncated)"
+        );
+      }
+      return stdout;
+    } catch {
+      try {
+        const { stdout } = await execFileAsync(
+          "find",
+          [
+            ".",
+            "-maxdepth",
+            "3",
+            "-not",
+            "-path",
+            "*/node_modules/*",
+            "-not",
+            "-path",
+            "*/.git/*",
+            "-not",
+            "-path",
+            "*/dist/*",
+            "-not",
+            "-path",
+            "*/build/*",
+          ],
+          { cwd: repoDir, timeout: 10_000, maxBuffer: 1024 * 1024 }
+        );
+        if (stdout.length > MAX_PROJECT_STRUCTURE_SIZE) {
+          return (
+            stdout.substring(0, MAX_PROJECT_STRUCTURE_SIZE) +
+            "\n... (truncated)"
+          );
+        }
+        return stdout;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn("Failed to get project structure.", {
+          error: message,
+          repoDir,
+        });
+        return "";
+      }
+    }
+  }
+
+  private async getProjectDocumentation(repoDir: string): Promise<string> {
+    const sections: string[] = [];
+
+    for (const fileName of PROJECT_DOC_FILES) {
+      const filePath = join(repoDir, fileName);
+      try {
+        if (!existsSync(filePath)) continue;
+        let content = await readFile(filePath, "utf-8");
+        if (content.length > MAX_DOC_SIZE) {
+          content =
+            content.substring(0, MAX_DOC_SIZE) + "\n... (truncated)";
+        }
+        sections.push(`### ${fileName}\n\n${content}`);
+        logger.debug(`Loaded project documentation: ${fileName}`, {
+          size: content.length,
+        });
+      } catch {
+        logger.debug(`Could not read project documentation: ${fileName}`);
+      }
+    }
+
+    return sections.join("\n\n");
+  }
+
+  // ============================================================
+  // Related files: imports from bug-targeted files
+  // ============================================================
+
+  private async getRelatedFileContents(
+    repoDir: string,
+    bugs: BugbotBug[],
+    excludePaths: Set<string>
+  ): Promise<Map<string, string>> {
+    const bugFilePaths = [...new Set(bugs.map((b) => b.filePath))];
+    const importedPaths = new Set<string>();
+
+    for (const bugFilePath of bugFilePaths) {
+      const absolutePath = join(repoDir, bugFilePath);
+      try {
+        const content = await readFile(absolutePath, "utf-8");
+        const imports = extractImportPaths(content);
+        const bugFileDir = dirname(bugFilePath);
+
+        for (const importPath of imports) {
+          const resolved = this.resolveImportPath(
+            repoDir,
+            bugFileDir,
+            importPath
+          );
+          if (resolved && !excludePaths.has(resolved)) {
+            importedPaths.add(resolved);
+          }
+        }
+      } catch {
+        logger.debug("Could not read bug file for import analysis.", {
+          filePath: bugFilePath,
+        });
+      }
+    }
+
+    const contents = new Map<string, string>();
+    let totalSize = 0;
+
+    for (const filePath of importedPaths) {
+      if (totalSize >= MAX_RELATED_CONTEXT_SIZE) break;
+
+      const absolutePath = join(repoDir, filePath);
+      try {
+        const content = await readFile(absolutePath, "utf-8");
+        const remainingBudget = MAX_RELATED_CONTEXT_SIZE - totalSize;
+        if (content.length > remainingBudget) {
+          contents.set(
+            filePath,
+            content.substring(0, remainingBudget) + "\n... (truncated)"
+          );
+          totalSize = MAX_RELATED_CONTEXT_SIZE;
+        } else {
+          contents.set(filePath, content);
+          totalSize += content.length;
+        }
+      } catch {
+        logger.debug("Could not read related file, skipping.", { filePath });
+      }
+    }
+
+    if (contents.size > 0) {
+      logger.info(`Loaded ${contents.size} related file(s) as context.`, {
+        filePaths: [...contents.keys()],
+        totalSize,
+      });
+    }
+
+    return contents;
+  }
+
+  private resolveImportPath(
+    repoDir: string,
+    fromDir: string,
+    importPath: string
+  ): string | null {
+    if (!importPath.startsWith(".")) return null;
+
+    const resolvedRelative = join(fromDir, importPath);
+
+    const extensions = ["", ".ts", ".tsx", ".js", ".jsx", ".mts", ".mjs"];
+    for (const ext of extensions) {
+      const candidate = resolvedRelative + ext;
+      if (existsSync(join(repoDir, candidate))) {
+        return candidate;
+      }
+    }
+
+    // In TypeScript projects, .js imports often map to .ts source files
+    if (importPath.endsWith(".js")) {
+      const tsVariants = [
+        resolvedRelative.replace(/\.js$/, ".ts"),
+        resolvedRelative.replace(/\.js$/, ".tsx"),
+      ];
+      for (const candidate of tsVariants) {
+        if (existsSync(join(repoDir, candidate))) {
+          return candidate;
+        }
+      }
+    }
+
+    const indexFiles = ["index.ts", "index.tsx", "index.js", "index.jsx"];
+    for (const indexFile of indexFiles) {
+      const candidate = join(resolvedRelative, indexFile);
+      if (existsSync(join(repoDir, candidate))) {
+        return candidate;
+      }
+    }
+
+    return null;
   }
 
   // ============================================================
@@ -424,6 +662,31 @@ function extractChangedFilePaths(diff: string): string[] {
       if (!seen.has(filePath)) {
         seen.add(filePath);
         paths.push(filePath);
+      }
+    }
+  }
+
+  return paths;
+}
+
+// ============================================================
+// Utility: extract relative import/require paths from source code
+// ============================================================
+
+function extractImportPaths(source: string): string[] {
+  const paths: string[] = [];
+  const seen = new Set<string>();
+
+  const fromRegex = /from\s+["']([^"']+)["']/g;
+  const requireRegex = /require\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+  for (const regex of [fromRegex, requireRegex]) {
+    let match;
+    while ((match = regex.exec(source)) !== null) {
+      const importPath = match[1];
+      if (importPath.startsWith(".") && !seen.has(importPath)) {
+        seen.add(importPath);
+        paths.push(importPath);
       }
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -256,7 +256,7 @@ class AutofixDaemon {
     const body =
       `${AUTOFIX_COMMENT_MARKER}\n` +
       `[Claude Code Bugbot Autofix](https://github.com/Senna46/claude-code-bugbot-autofix) ` +
-      `committed a fix for ${bugCount} of the ${bugCount} bugs found. ` +
+      `committed fixes for ${bugCount} bug(s). ` +
       `([${commitShort}](${commitUrl}))\n\n` +
       fixedList;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -246,14 +246,19 @@ class AutofixDaemon {
     const commitUrl = `https://github.com/${pr.owner}/${pr.repo}/commit/${fixResult.commitSha}`;
 
     const fixedList = fixResult.fixedBugs
-      .map((fb) => `- **${fb.title}**`)
+      .map(
+        (fb) =>
+          `- ✅ Fixed: **${fb.title}**\n  - ${fb.description}`
+      )
       .join("\n");
 
+    const bugCount = fixResult.fixedBugs.length;
     const body =
       `${AUTOFIX_COMMENT_MARKER}\n` +
-      `[Claude Code Bugbot Autofix](https://github.com/Senna46/claude-code-bugbot-autofix) committed fixes to address ` +
-      `${fixResult.fixedBugs.length} Cursor Bugbot issue(s) ([${commitShort}](${commitUrl})).\n\n` +
-      `**Fixed issues:**\n${fixedList}`;
+      `[Claude Code Bugbot Autofix](https://github.com/Senna46/claude-code-bugbot-autofix) ` +
+      `committed a fix for ${bugCount} of the ${bugCount} bugs found. ` +
+      `([${commitShort}](${commitUrl}))\n\n` +
+      fixedList;
 
     try {
       await this.github.createIssueComment(


### PR DESCRIPTION
## Summary

- Expand allowed tools for claude -p to include read-only shell commands (find, grep, rg, ls, cat, head, tail, wc, tree) enabling full codebase exploration during fix generation
- Add project structure (tree), documentation (CLAUDE.md, AGENTS.md, README.md), and related file context (import/require dependency resolution) to the fix prompt
- Restructure prompt with explicit instructions for codebase exploration before making changes, with constraints against creating new files or modifying unrelated code
- Improve commit messages with AI-generated summary from claude -p stdout, "Applied via Claude Code Bugbot Autofix" attribution
- Update PR comment format to match Cursor Bugbot Autofix style with checkmark-prefixed bug titles and descriptions

## Test plan

- [ ] Deploy and verify fix generation against a PR with Cursor Bugbot review comments
- [ ] Confirm project structure and documentation appear in the prompt
- [ ] Confirm related files from import analysis are included as context
- [ ] Verify commit message includes AI-generated summary when available, falls back gracefully
- [ ] Verify PR comment uses new format with checkmarks and descriptions


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alter how the autofix agent is prompted and what shell commands it can run, which can impact safety/behavior and fix correctness. Also modifies commit/comment output formatting and parsing of Claude output, which could fail on unexpected output formats.
> 
> **Overview**
> Improves autofix quality by expanding the `claude -p` prompt with more repository context (project structure via `tree`/`find`, selected top-level docs, PR diff, changed file contents, and a size-bounded set of related imported files resolved from bug-targeted sources).
> 
> Enables additional read-only exploration tools during fix generation and restructures the prompt with explicit constraints and a required `COMMIT_MSG:` one-line summary output.
> 
> Uses Claude stdout to derive a more specific commit title (with fallbacks) and updates the PR comment format to include per-bug descriptions and a clearer “✅ Fixed” list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e67b3eb20e51e943f066958231e6c825557ced31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->