### PR TITLE
fix: prevent duplicate conventional commit prefix in generated commit messages

### DIFF
--- a/src/fixGenerator.ts
+++ b/src/fixGenerator.ts
@@ -764,7 +764,7 @@ function extractImportPaths(source: string): string[] {
 // ============================================================
 
 const CONVENTIONAL_COMMIT_REGEX =
-  /^(fix|feat|chore|refactor|perf|test|docs|style|build|ci|revert)(\(.+?\))?:\s/i;
+  /^(fix|feat|chore|refactor|perf|test|docs|style|build|ci|revert)(\(.+?\))?!?:\s/i;
 
 function hasConventionalCommitPrefix(message: string): boolean {
   return CONVENTIONAL_COMMIT_REGEX.test(message);

--- a/src/fixGenerator.ts
+++ b/src/fixGenerator.ts
@@ -683,7 +683,9 @@ export class FixGenerator {
     await this.execGit(repoDir, ["add", "-A"]);
 
     const title = commitSummary
-      ? `fix: ${commitSummary}`
+      ? hasConventionalCommitPrefix(commitSummary)
+        ? commitSummary
+        : `fix: ${commitSummary}`
       : bugs.length === 1
       ? `fix: ${bugs[0].title}`
       : "fix: Fix Cursor Bugbot issues";
@@ -755,6 +757,17 @@ function extractImportPaths(source: string): string[] {
   }
 
   return paths;
+}
+
+// ============================================================
+// Utility: check for conventional commit prefix
+// ============================================================
+
+const CONVENTIONAL_COMMIT_REGEX =
+  /^(fix|feat|chore|refactor|perf|test|docs|style|build|ci|revert)(\(.+?\))?:\s/i;
+
+function hasConventionalCommitPrefix(message: string): boolean {
+  return CONVENTIONAL_COMMIT_REGEX.test(message);
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- `claude -p` が `COMMIT_MSG: fix: add null check` のように conventional commit prefix 付きのメッセージを出力した場合、`commitAndPush` が更に `fix:` を付加して `fix: fix: add null check` になる問題を修正
- `hasConventionalCommitPrefix()` 関数を追加し、既存のプレフィックス（fix, feat, chore, refactor 等）を検出してそのまま使用するように変更

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run build` succeeds
- [ ] Verify `COMMIT_MSG: fix: something` produces `fix: something` (not `fix: fix: something`)
- [ ] Verify `COMMIT_MSG: feat: something` produces `feat: something` (not `fix: feat: something`)
- [ ] Verify `COMMIT_MSG: add null check` (no prefix) still produces `fix: add null check`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to commit message formatting only; minimal functional impact outside git metadata.
> 
> **Overview**
> Prevents duplicate `fix:` prefixes in Bugbot autofix commit titles by detecting when `COMMIT_MSG:` already contains a conventional-commit prefix.
> 
> Adds `hasConventionalCommitPrefix()` (backed by a regex for common conventional commit types) and updates `commitAndPush()` to use the provided summary verbatim when it matches, otherwise continuing to prepend `fix:` as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03a23c82dd8f3a9e210b0dd0e702919201d8bf78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->