### PR TITLE
feat: update project name in package-lock and README for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,69 +246,17 @@ docker compose down -v     # Remove with data
 
 ### macOS (launchd)
 
-Build the project first:
+To run as a native LaunchAgent (starts on login, restarts on failure), use the install script. See [deploy/README.md](deploy/README.md) for details.
+
+From the project root:
 
 ```bash
 npm run build
+chmod +x deploy/install-daemon.sh
+./deploy/install-daemon.sh
 ```
 
-Create `~/Library/LaunchAgents/com.bugbot-autofix.plist`:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>com.bugbot-autofix</string>
-
-  <key>ProgramArguments</key>
-  <array>
-    <string>/path/to/node</string>
-    <string>dist/main.js</string>
-  </array>
-
-  <key>WorkingDirectory</key>
-  <string>/path/to/claude-code-bugbot-autofix</string>
-
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>PATH</key>
-    <string>/path/to/node/bin:/usr/local/bin:/usr/bin:/bin</string>
-    <key>HOME</key>
-    <string>/Users/yourname</string>
-  </dict>
-
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-
-  <key>StandardOutPath</key>
-  <string>/path/to/claude-code-bugbot-autofix/logs/stdout.log</string>
-  <key>StandardErrorPath</key>
-  <string>/path/to/claude-code-bugbot-autofix/logs/stderr.log</string>
-</dict>
-</plist>
-```
-
-Replace `/path/to/node` with the output of `which node`, and update paths accordingly.
-
-```bash
-# Load (start) the daemon
-launchctl load -w ~/Library/LaunchAgents/com.bugbot-autofix.plist
-
-# Unload (stop) the daemon
-launchctl unload ~/Library/LaunchAgents/com.bugbot-autofix.plist
-
-# Check status
-launchctl list | grep bugbot
-
-# View logs
-tail -f logs/stdout.log
-tail -f logs/stderr.log
-```
+Logs: `~/.bugbot-autofix/logs/stdout.log` and `~/.bugbot-autofix/logs/stderr.log`.
 
 Alternatively, run directly with `nohup`:
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,43 @@
+# Bugbot Autofix Daemon (launchd)
+
+Run the Autofix daemon as a native macOS LaunchAgent so it starts on login and restarts on failure.
+
+## Prerequisites
+
+- `.env` configured (copy from `.env.example` and set `AUTOFIX_GITHUB_ORGS` or `AUTOFIX_GITHUB_REPOS`, tokens, etc.)
+- `npm run build` completed
+- `claude` CLI installed and on PATH (`~/.local/bin` is included by default)
+
+## Install
+
+From the project root:
+
+```bash
+chmod +x deploy/install-daemon.sh
+./deploy/install-daemon.sh
+```
+
+The script copies the LaunchAgent plist to `~/Library/LaunchAgents/` (with paths substituted), creates `~/.bugbot-autofix/logs/`, and loads the job.
+
+## Commands
+
+| Action | Command |
+|--------|---------|
+| Check status | `launchctl list | grep bugbot` |
+| Stop | `launchctl stop com.senna.bugbot-autofix` |
+| Start | `launchctl start com.senna.bugbot-autofix` |
+| Unload (disable) | `launchctl unload ~/Library/LaunchAgents/com.senna.bugbot-autofix.plist` |
+| View stdout | `tail -f ~/.bugbot-autofix/logs/stdout.log` |
+| View stderr | `tail -f ~/.bugbot-autofix/logs/stderr.log` |
+
+## Update after code changes
+
+1. `npm run build`
+2. `launchctl stop com.senna.bugbot-autofix && launchctl start com.senna.bugbot-autofix`
+
+## Uninstall
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.senna.bugbot-autofix.plist
+rm ~/Library/LaunchAgents/com.senna.bugbot-autofix.plist
+```

--- a/deploy/autofix-daemon.plist
+++ b/deploy/autofix-daemon.plist
@@ -7,7 +7,7 @@
 
 	<key>ProgramArguments</key>
 	<array>
-		<string>/opt/homebrew/bin/node</string>
+		<string>__NODE_PATH__</string>
 		<string>__PROJECT_ROOT__/dist/main.js</string>
 	</array>
 

--- a/deploy/autofix-daemon.plist
+++ b/deploy/autofix-daemon.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.senna.bugbot-autofix</string>
+
+	<key>ProgramArguments</key>
+	<array>
+		<string>/opt/homebrew/bin/node</string>
+		<string>__PROJECT_ROOT__/dist/main.js</string>
+	</array>
+
+	<key>WorkingDirectory</key>
+	<string>__PROJECT_ROOT__</string>
+
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<key>HOME</key>
+		<string>__HOME__</string>
+	</dict>
+
+	<key>RunAtLoad</key>
+	<true/>
+
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+
+	<key>StandardOutPath</key>
+	<string>__HOME__/.bugbot-autofix/logs/stdout.log</string>
+
+	<key>StandardErrorPath</key>
+	<string>__HOME__/.bugbot-autofix/logs/stderr.log</string>
+
+	<key>ThrottleInterval</key>
+	<integer>30</integer>
+</dict>
+</plist>

--- a/deploy/install-daemon.sh
+++ b/deploy/install-daemon.sh
@@ -20,8 +20,15 @@ if [ ! -f "$PROJECT_ROOT/.env" ]; then
   echo "Warning: .env not found. Copy .env.example to .env and configure."
 fi
 
+NODE_PATH="$(which node)"
+if [ -z "$NODE_PATH" ]; then
+  echo "Error: node not found in PATH. Install Node.js first."
+  exit 1
+fi
+
 mkdir -p "$LOG_DIR"
-sed -e "s|__PROJECT_ROOT__|$PROJECT_ROOT|g" -e "s|__HOME__|$HOME|g" \
+mkdir -p "$LAUNCH_AGENTS"
+sed -e "s|__PROJECT_ROOT__|$PROJECT_ROOT|g" -e "s|__HOME__|$HOME|g" -e "s|__NODE_PATH__|$NODE_PATH|g" \
   "$SCRIPT_DIR/autofix-daemon.plist" > "$PLIST_DEST"
 chmod 644 "$PLIST_DEST"
 

--- a/deploy/install-daemon.sh
+++ b/deploy/install-daemon.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Installs Bugbot Autofix as a user LaunchAgent (runs on login, restarts on failure).
+# Run from the project root: ./deploy/install-daemon.sh
+# Requires: npm run build already done, .env configured.
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLIST_NAME="com.senna.bugbot-autofix"
+LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
+PLIST_DEST="${LAUNCH_AGENTS}/${PLIST_NAME}.plist"
+LOG_DIR="${HOME}/.bugbot-autofix/logs"
+
+if [ ! -f "$PROJECT_ROOT/dist/main.js" ]; then
+  echo "Error: dist/main.js not found. Run 'npm run build' first."
+  exit 1
+fi
+
+if [ ! -f "$PROJECT_ROOT/.env" ]; then
+  echo "Warning: .env not found. Copy .env.example to .env and configure."
+fi
+
+mkdir -p "$LOG_DIR"
+sed -e "s|__PROJECT_ROOT__|$PROJECT_ROOT|g" -e "s|__HOME__|$HOME|g" \
+  "$SCRIPT_DIR/autofix-daemon.plist" > "$PLIST_DEST"
+chmod 644 "$PLIST_DEST"
+
+launchctl unload "$PLIST_DEST" 2>/dev/null || true
+launchctl load "$PLIST_DEST"
+echo "Bugbot Autofix daemon installed. Logs: $LOG_DIR/stdout.log and $LOG_DIR/stderr.log"
+echo "Commands: launchctl list | grep bugbot | start/stop: launchctl start/stop $PLIST_NAME"

--- a/deploy/install-daemon.sh
+++ b/deploy/install-daemon.sh
@@ -20,15 +20,23 @@ if [ ! -f "$PROJECT_ROOT/.env" ]; then
   echo "Warning: .env not found. Copy .env.example to .env and configure."
 fi
 
-NODE_PATH="$(which node)"
-if [ -z "$NODE_PATH" ]; then
+NODE_BIN="$(which node)"
+if [ -z "$NODE_BIN" ]; then
   echo "Error: node not found in PATH. Install Node.js first."
   exit 1
 fi
 
+# Escape sed-special characters in replacement values (& and | with | delimiter)
+escape_sed() {
+  printf '%s\n' "$1" | sed -e 's/[&\\/|]/\\&/g'
+}
+SAFE_PROJECT_ROOT="$(escape_sed "$PROJECT_ROOT")"
+SAFE_HOME="$(escape_sed "$HOME")"
+SAFE_NODE_BIN="$(escape_sed "$NODE_BIN")"
+
 mkdir -p "$LOG_DIR"
 mkdir -p "$LAUNCH_AGENTS"
-sed -e "s|__PROJECT_ROOT__|$PROJECT_ROOT|g" -e "s|__HOME__|$HOME|g" -e "s|__NODE_PATH__|$NODE_PATH|g" \
+sed -e "s|__PROJECT_ROOT__|$SAFE_PROJECT_ROOT|g" -e "s|__HOME__|$SAFE_HOME|g" -e "s|__NODE_PATH__|$SAFE_NODE_BIN|g" \
   "$SCRIPT_DIR/autofix-daemon.plist" > "$PLIST_DEST"
 chmod 644 "$PLIST_DEST"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "bugbot-autofix",
+  "name": "claude-code-bugbot-autofix",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bugbot-autofix",
+      "name": "claude-code-bugbot-autofix",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- Changed project name from "bugbot-autofix" to "claude-code-bugbot-autofix" in package-lock.json.
- Updated README to reflect new installation instructions for macOS LaunchAgent, including the use of an install script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/config change that adds a macOS LaunchAgent installer; main risk is users installing a misconfigured daemon (paths/PATH) if their environment differs.
> 
> **Overview**
> Updates the macOS *launchd* instructions to use a new `deploy/install-daemon.sh` installer instead of manually creating a plist, and documents the new log location under `~/.bugbot-autofix/logs/`.
> 
> Adds `deploy/autofix-daemon.plist` (template with path placeholders), a `deploy/README.md` with install/start/stop/uninstall commands, and aligns the `package-lock.json` project name with `package.json` (`claude-code-bugbot-autofix`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbdf34179a1d5e20724f1c33c7ca1738f090d7fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->