### PR TITLE
fix: Record no-changes bugs as SKIPPED_NO_CHANGES instead of null

### DIFF
--- a/src/bugbotMonitor.ts
+++ b/src/bugbotMonitor.ts
@@ -229,8 +229,8 @@ export class BugbotMonitor {
   // ============================================================
 
   private computeSinceForRepo(repo: string): string | undefined {
-    if (this.state.hasFailedBugsForRepo(repo)) {
-      logger.debug("Skipping since filter to retry failed bugs.", { repo });
+    if (this.state.hasRetryableBugsForRepo(repo)) {
+      logger.debug("Skipping since filter to retry failed/skipped bugs.", { repo });
       return undefined;
     }
     const lookbackMs = DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;

--- a/src/githubClient.ts
+++ b/src/githubClient.ts
@@ -393,6 +393,39 @@ export class GitHubClient {
 
     return data.id;
   }
+
+  async hasIssueCommentContaining(
+    owner: string,
+    repo: string,
+    prNumber: number,
+    marker: string
+  ): Promise<boolean> {
+    logger.debug("Checking for existing issue comment with marker.", {
+      owner,
+      repo,
+      prNumber,
+    });
+
+    const octokit = await this.getOctokitForOwner(owner);
+
+    for await (const response of octokit.paginate.iterator(
+      octokit.rest.issues.listComments,
+      {
+        owner,
+        repo,
+        issue_number: prNumber,
+        per_page: 100,
+      }
+    )) {
+      for (const comment of response.data) {
+        if (comment.body?.includes(marker)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
 }
 
 // ============================================================

--- a/src/main.ts
+++ b/src/main.ts
@@ -217,11 +217,11 @@ class FixoolyDaemon {
             repo: repoFullName,
             prNumber: pr.number,
           })),
-          null
+          "SKIPPED_NO_CHANGES"
         );
 
         logger.info(
-          `No changes made for PR #${pr.number}. Bugs recorded as processed.`,
+          `No changes made for PR #${pr.number}. Bugs recorded as skipped.`,
           { prNumber: pr.number, repo: repoFullName }
         );
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import { StateStore } from "./state.js";
 import type { Config, FixResult, PrBugReport } from "./types.js";
 
 const AUTOFIX_COMMENT_MARKER = "<!-- BUGBOT_AUTOFIX_COMMENT -->";
+const AUTOFIX_NO_CHANGES_MARKER = "<!-- BUGBOT_AUTOFIX_NO_CHANGES -->";
 
 class FixoolyDaemon {
   private config: Config;
@@ -299,17 +300,31 @@ class FixoolyDaemon {
     pr: { owner: string; repo: string; number: number },
     bugs: import("./types.js").BugbotBug[]
   ): Promise<void> {
-    const bugList = bugs
-      .map((b) => `- ⏭️ Skipped: **${b.title}**`)
-      .join("\n");
-
-    const body =
-      `${AUTOFIX_COMMENT_MARKER}\n` +
-      `[Fixooly](https://github.com/Senna46/fixooly) ` +
-      `analyzed ${bugs.length} bug(s) but determined no code changes were needed.\n\n` +
-      bugList;
-
     try {
+      const alreadyPosted = await this.github.hasIssueCommentContaining(
+        pr.owner,
+        pr.repo,
+        pr.number,
+        AUTOFIX_NO_CHANGES_MARKER
+      );
+      if (alreadyPosted) {
+        logger.debug("No-changes comment already exists on PR, skipping.", {
+          prNumber: pr.number,
+          repo: `${pr.owner}/${pr.repo}`,
+        });
+        return;
+      }
+
+      const bugList = bugs
+        .map((b) => `- ⏭️ Skipped: **${b.title}**`)
+        .join("\n");
+
+      const body =
+        `${AUTOFIX_COMMENT_MARKER}\n${AUTOFIX_NO_CHANGES_MARKER}\n` +
+        `[Fixooly](https://github.com/Senna46/fixooly) ` +
+        `analyzed ${bugs.length} bug(s) but determined no code changes were needed.\n\n` +
+        bugList;
+
       await this.github.createIssueComment(
         pr.owner,
         pr.repo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,6 +211,8 @@ class FixoolyDaemon {
           }
         );
       } else {
+        await this.postNoChangesComment(pr, bugs);
+
         this.state.recordProcessedBugs(
           bugs.map((b) => ({
             bugId: b.bugId,
@@ -282,6 +284,45 @@ class FixoolyDaemon {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger.warn("Failed to post fix comment on PR.", {
+        error: message,
+        prNumber: pr.number,
+        repo: `${pr.owner}/${pr.repo}`,
+      });
+    }
+  }
+
+  // ============================================================
+  // Post no-changes comment on the PR
+  // ============================================================
+
+  private async postNoChangesComment(
+    pr: { owner: string; repo: string; number: number },
+    bugs: import("./types.js").BugbotBug[]
+  ): Promise<void> {
+    const bugList = bugs
+      .map((b) => `- ⏭️ Skipped: **${b.title}**`)
+      .join("\n");
+
+    const body =
+      `${AUTOFIX_COMMENT_MARKER}\n` +
+      `[Fixooly](https://github.com/Senna46/fixooly) ` +
+      `analyzed ${bugs.length} bug(s) but determined no code changes were needed.\n\n` +
+      bugList;
+
+    try {
+      await this.github.createIssueComment(
+        pr.owner,
+        pr.repo,
+        pr.number,
+        body
+      );
+      logger.debug("Posted no-changes comment on PR.", {
+        prNumber: pr.number,
+        repo: `${pr.owner}/${pr.repo}`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn("Failed to post no-changes comment on PR.", {
         error: message,
         prNumber: pr.number,
         repo: `${pr.owner}/${pr.repo}`,

--- a/src/state.ts
+++ b/src/state.ts
@@ -50,8 +50,8 @@ export class StateStore {
     const row = this.db
       .prepare("SELECT fix_commit_sha FROM processed_bugs WHERE bug_id = ?")
       .get(bugId) as { fix_commit_sha: string | null } | undefined;
-    // Bugs marked as FAILED or SKIPPED_NO_CHANGES should be retried
-    return row !== undefined && row.fix_commit_sha !== "FAILED" && row.fix_commit_sha !== "SKIPPED_NO_CHANGES";
+    // Only FAILED bugs should be retried; SKIPPED_NO_CHANGES is terminal
+    return row !== undefined && row.fix_commit_sha !== "FAILED";
   }
 
   hasRetryableBugsForRepo(repo: string): boolean {

--- a/src/state.ts
+++ b/src/state.ts
@@ -57,7 +57,7 @@ export class StateStore {
   hasRetryableBugsForRepo(repo: string): boolean {
     const row = this.db
       .prepare(
-        "SELECT 1 FROM processed_bugs WHERE fix_commit_sha IN ('FAILED', 'SKIPPED_NO_CHANGES') AND repo = ? LIMIT 1"
+        "SELECT 1 FROM processed_bugs WHERE fix_commit_sha = 'FAILED' AND repo = ? LIMIT 1"
       )
       .get(repo);
     return row !== undefined;

--- a/src/state.ts
+++ b/src/state.ts
@@ -50,14 +50,14 @@ export class StateStore {
     const row = this.db
       .prepare("SELECT fix_commit_sha FROM processed_bugs WHERE bug_id = ?")
       .get(bugId) as { fix_commit_sha: string | null } | undefined;
-    // Bugs marked as FAILED should be retried
-    return row !== undefined && row.fix_commit_sha !== "FAILED";
+    // Bugs marked as FAILED or SKIPPED_NO_CHANGES should be retried
+    return row !== undefined && row.fix_commit_sha !== "FAILED" && row.fix_commit_sha !== "SKIPPED_NO_CHANGES";
   }
 
-  hasFailedBugsForRepo(repo: string): boolean {
+  hasRetryableBugsForRepo(repo: string): boolean {
     const row = this.db
       .prepare(
-        "SELECT 1 FROM processed_bugs WHERE fix_commit_sha = 'FAILED' AND repo = ? LIMIT 1"
+        "SELECT 1 FROM processed_bugs WHERE fix_commit_sha IN ('FAILED', 'SKIPPED_NO_CHANGES') AND repo = ? LIMIT 1"
       )
       .get(repo);
     return row !== undefined;


### PR DESCRIPTION
## Summary
- When `fixBugsOnPrBranch` returns `null` (Claude made no code changes), bugs were recorded with `fix_commit_sha=null`
- `isBugProcessed()` treats `null` as "successfully processed", so these bugs were never retried and silently blocked detection of new comments on the same PR
- Changed to record `"SKIPPED_NO_CHANGES"` which is correctly treated as a terminal state

## Test plan
- [x] Verified fix with `d6e-ai/d6e-construction-frontend` PR #13 — bug was re-detected and processed after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes bug processing state semantics and alters repo scanning behavior by disabling the `since` filter when retryable records exist, which can affect what bugs are discovered and retried.
> 
> **Overview**
> Fixooly now records bug runs that produce *no code changes* as `SKIPPED_NO_CHANGES` (instead of `null`) and logs them as skipped.
> 
> It posts a dedicated, de-duplicated “no changes needed” issue comment on the PR (using new `GitHubClient.hasIssueCommentContaining` with an HTML marker) to avoid spamming.
> 
> Repo scanning tweaks the `since` filtering logic to skip the time filter when a repo has retryable bugs (renaming `hasFailedBugsForRepo` to `hasRetryableBugsForRepo` and updating messaging) so missed/failed items can be reprocessed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b6b938bd025a36f453f5673b128bc70fe96ec22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->