### PR TITLE
chore: Remove fix: prefix from auto-generated commit titles

### DIFF
--- a/src/fixGenerator.ts
+++ b/src/fixGenerator.ts
@@ -702,7 +702,7 @@ export class FixGenerator {
     await this.execGit(repoDir, ["add", "-A"]);
 
     const title = commitSummary
-      ? stripConventionalCommitPrefix(commitSummary)
+      ? commitSummary
       : bugs.length === 1
       ? bugs[0].title
       : "Fix Cursor Bugbot issues";
@@ -838,17 +838,6 @@ function extractImportPaths(source: string): string[] {
   }
 
   return paths;
-}
-
-// ============================================================
-// Utility: strip conventional commit prefix from a message
-// ============================================================
-
-const CONVENTIONAL_COMMIT_REGEX =
-  /^(fix|feat|chore|refactor|perf|test|docs|style|build|ci|revert)(\(.+?\))?!?:\s/i;
-
-function stripConventionalCommitPrefix(message: string): string {
-  return message.replace(CONVENTIONAL_COMMIT_REGEX, "");
 }
 
 // ============================================================

--- a/src/fixGenerator.ts
+++ b/src/fixGenerator.ts
@@ -702,7 +702,7 @@ export class FixGenerator {
     await this.execGit(repoDir, ["add", "-A"]);
 
     const title = commitSummary
-      ? commitSummary
+      ? stripConventionalCommitPrefix(commitSummary)
       : bugs.length === 1
       ? bugs[0].title
       : "Fix Cursor Bugbot issues";
@@ -838,6 +838,17 @@ function extractImportPaths(source: string): string[] {
   }
 
   return paths;
+}
+
+// ============================================================
+// Utility: strip conventional commit prefix from a message
+// ============================================================
+
+const CONVENTIONAL_COMMIT_REGEX =
+  /^(fix|feat|chore|refactor|perf|test|docs|style|build|ci|revert)(\(.+?\))?!?:\s/i;
+
+function stripConventionalCommitPrefix(message: string): string {
+  return message.replace(CONVENTIONAL_COMMIT_REGEX, "");
 }
 
 // ============================================================

--- a/src/fixGenerator.ts
+++ b/src/fixGenerator.ts
@@ -702,12 +702,10 @@ export class FixGenerator {
     await this.execGit(repoDir, ["add", "-A"]);
 
     const title = commitSummary
-      ? hasConventionalCommitPrefix(commitSummary)
-        ? commitSummary
-        : `fix: ${commitSummary}`
+      ? stripConventionalCommitPrefix(commitSummary)
       : bugs.length === 1
-      ? `fix: ${bugs[0].title}`
-      : "fix: Fix Cursor Bugbot issues";
+      ? bugs[0].title
+      : "Fix Cursor Bugbot issues";
 
     const bugTitles = bugs.map((b) => `- ${b.title}`).join("\n");
     const commitMessage = `${title}\n\n${bugTitles}\n\nApplied via Fixooly`;
@@ -847,10 +845,10 @@ function extractImportPaths(source: string): string[] {
 // ============================================================
 
 const CONVENTIONAL_COMMIT_REGEX =
-  /^(fix|feat|chore|refactor|perf|test|docs|style|build|ci|revert)(\(.+?\))?!?:\s/i;
+  /^(fix|feat|chore|refactor|perf|test|docs|style|build|ci|revert)(\(.+?\))?!?:\s+/i;
 
-function hasConventionalCommitPrefix(message: string): boolean {
-  return CONVENTIONAL_COMMIT_REGEX.test(message);
+function stripConventionalCommitPrefix(message: string): string {
+  return message.replace(CONVENTIONAL_COMMIT_REGEX, "").trim() || message;
 }
 
 // ============================================================

--- a/src/fixGenerator.ts
+++ b/src/fixGenerator.ts
@@ -702,7 +702,7 @@ export class FixGenerator {
     await this.execGit(repoDir, ["add", "-A"]);
 
     const title = commitSummary
-      ? stripConventionalCommitPrefix(commitSummary)
+      ? commitSummary
       : bugs.length === 1
       ? bugs[0].title
       : "Fix Cursor Bugbot issues";
@@ -838,17 +838,6 @@ function extractImportPaths(source: string): string[] {
   }
 
   return paths;
-}
-
-// ============================================================
-// Utility: check for conventional commit prefix
-// ============================================================
-
-const CONVENTIONAL_COMMIT_REGEX =
-  /^(fix|feat|chore|refactor|perf|test|docs|style|build|ci|revert)(\(.+?\))?!?:\s+/i;
-
-function stripConventionalCommitPrefix(message: string): string {
-  return message.replace(CONVENTIONAL_COMMIT_REGEX, "").trim() || message;
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
- Strip any conventional commit prefix from Claude's returned `COMMIT_MSG` summary
- Drop the hardcoded `fix:` fallback so auto-fix commits read as plain descriptive titles

## Test plan
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Observe next auto-fix commit and confirm no `fix:` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how automated fix commits are titled and removes unused conventional-commit prefix detection, with no impact on fix logic or git operations beyond commit message text.
> 
> **Overview**
> Auto-generated fix commits no longer force a `fix:` conventional-commit prefix. `commitAndPush` now uses Claude’s `COMMIT_MSG` verbatim when present, and the fallback titles are changed to plain bug titles / `Fix Cursor Bugbot issues`.
> 
> Removes the unused conventional-commit prefix detection helper (`CONVENTIONAL_COMMIT_REGEX` / `hasConventionalCommitPrefix`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c31225fbb8aab456f3e5e99421488ed15efcb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->