### PR TITLE
Add multi-backend fixer support (Claude / Codex / Cursor)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,19 +27,61 @@ AUTOFIX_WORK_DIR=
 # SQLite database path (default: ~/.fixooly/state.db)
 AUTOFIX_DB_PATH=
 
-# Claude model override (optional, uses default if empty)
-AUTOFIX_CLAUDE_MODEL=
-
 # Log level: debug, info, warn, error (default: info)
 AUTOFIX_LOG_LEVEL=info
 
 # ============================================================
-# AI Authentication
+# Bug-fix Backend Selection
 # ============================================================
 
-# Claude Code OAuth token (required on macOS Docker)
+# Which CLI Fixooly uses to generate fixes (required, no default).
+# Supported values:
+#   cursor -- Cursor CLI (agent -p). Recommended for daemon use: no
+#             5-hour rolling rate limit, monthly Auto+Composer pool
+#             on the Cursor Pro plan, simple CURSOR_API_KEY auth.
+#   codex  -- OpenAI Codex CLI (codex exec). Subject to a 5-hour
+#             rolling rate limit and a weekly cap on ChatGPT Plus/Pro,
+#             which can interrupt long polling daemons.
+#   claude -- Anthropic Claude Code CLI (claude -p). Legacy backend
+#             kept for compatibility with existing deployments.
+AUTOFIX_FIXER=cursor
+
+# ============================================================
+# Cursor CLI (used when AUTOFIX_FIXER=cursor)
+# ============================================================
+
+# Model override for Cursor CLI. Recommended values for staying inside
+# the Cursor Pro flat rate: "auto" (cost-optimised router) or
+# "composer-2.5" (Cursor's own agentic coding model). Leaving this
+# unset uses the CLI's default.
+AUTOFIX_CURSOR_MODEL=auto
+
+# Cursor API key for headless use. Generate from the Cursor settings
+# page. Without this the CLI falls back to an interactive login, which
+# is unsuitable for daemons.
+CURSOR_API_KEY=
+
+# ============================================================
+# Codex CLI (used when AUTOFIX_FIXER=codex)
+# ============================================================
+
+# Model override for codex exec. The coding-tuned model is recommended.
+AUTOFIX_CODEX_MODEL=gpt-5.3-codex
+
+# Codex API key for headless use. Alternatively, copy ~/.codex/auth.json
+# from an interactive machine to authenticate via a ChatGPT subscription.
+CODEX_API_KEY=
+
+# ============================================================
+# Claude Code CLI (used when AUTOFIX_FIXER=claude) -- legacy
+# ============================================================
+
+# Model override for claude -p (optional, uses CLI default if empty).
+AUTOFIX_CLAUDE_MODEL=
+
+# Claude Code OAuth token (required on macOS Docker).
 # Generate with: claude setup-token
 CLAUDE_CODE_OAUTH_TOKEN=
 
-# Or use Anthropic API key for pay-as-you-go
+# Or use the Anthropic API key for pay-as-you-go billing.
 ANTHROPIC_API_KEY=

--- a/.plans/multi-backend-fixer.plan.md
+++ b/.plans/multi-backend-fixer.plan.md
@@ -1,0 +1,199 @@
+# Fixooly Multi-Backend Fixer Support
+
+## 背景
+
+Anthropic Claude のサブスクリプションを解約するため、Fixooly のバグ修正バックエンドを Claude CLI (`claude -p`) から **Cursor CLI (`agent -p`)** または **OpenAI Codex CLI (`codex exec`)** に移行可能にする。調査結果として:
+
+- **Cursor CLI**: 月次プールのみで時間ウィンドウ制限なし、`CURSOR_API_KEY` のみで認証完結、`--trust` で headless 専用フラグあり → **daemon 用途に最適**
+- **Codex CLI**: 5時間ローリング + 週次の二重制限、`auth.json` または `CODEX_API_KEY` で認証 → daemon の24/7稼働ではピーク時に枯渇しやすい
+
+ユーザーは新規 **Cursor Pro ($20/月)** を契約予定。既存 Claude サポートも残し、3バックエンド切替可能とする。
+
+## アーキテクチャ
+
+```mermaid
+flowchart TD
+    Main[main.ts] --> Config[config.ts loadConfig]
+    Config --> Factory["fixers/factory.ts createFixer(config)"]
+    Factory -->|AUTOFIX_FIXER=claude| Claude[ClaudeFixer]
+    Factory -->|AUTOFIX_FIXER=codex| Codex[CodexFixer]
+    Factory -->|AUTOFIX_FIXER=cursor| Cursor[CursorFixer]
+    Claude -.implements.-> IFixer[BugFixer interface]
+    Codex -.implements.-> IFixer
+    Cursor -.implements.-> IFixer
+    Main --> FG[FixGenerator]
+    FG -->|DI| IFixer
+    FG --> Clone[clone/checkout/diff/context]
+    FG --> CommitPush[commit + push]
+    IFixer -->|generateFix prompt cwd| ChildProc[child_process spawn]
+```
+
+## 1. 新規モジュール構成
+
+### `src/fixers/types.ts` - 共通インターフェース
+
+```typescript
+export interface BugFixer {
+  readonly name: "claude" | "codex" | "cursor";
+  verifyPrerequisites(): Promise<void>;
+  generateFix(input: FixerInput): Promise<string>;
+}
+
+export interface FixerInput {
+  cwd: string;
+  prompt: string;
+  timeoutMs: number;
+}
+```
+
+### `src/fixers/claudeFixer.ts` - 既存実装を切り出し
+
+現在の `runClaudeFix` を `ClaudeFixer.generateFix` として移動。`ALLOWED_TOOLS` 定数と `--model` 引数もここに集約。`verifyPrerequisites` で `claude --version` と `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` をチェック。
+
+### `src/fixers/cursorFixer.ts` - 新規実装
+
+`agent -p --force --trust --workspace <cwd> --output-format json [--model <model>]` で呼び出し、プロンプトは stdin へ。
+
+- `--force`: ファイル編集の承認スキップ
+- `--trust`: headless モードのワークスペース信頼
+- `--workspace`: 作業ディレクトリ指定 (cwd 代替)
+- `--output-format json`: 結果を構造化取得
+- `--model`: `AUTOFIX_CURSOR_MODEL` (推奨デフォルト `auto` または `composer-2.5`)
+
+`verifyPrerequisites` で `agent --version` (もしくは `cursor-agent --version`) と `CURSOR_API_KEY` をチェック。
+
+### `src/fixers/codexFixer.ts` - 新規実装
+
+`codex exec --sandbox workspace-write --ask-for-approval never --cd <cwd> --json --skip-git-repo-check [--model <model>]` で呼び出し、プロンプトは stdin へ。
+
+- `--sandbox workspace-write`: ワークスペース内編集のみ許可 (現状の Claude `allowedTools` 相当)
+- `--ask-for-approval never`: 非対話実行
+- `--cd`: 作業ディレクトリ指定
+- `--json`: JSONL イベント出力
+- `--model`: `AUTOFIX_CODEX_MODEL` (推奨 `gpt-5.3-codex`)
+
+`verifyPrerequisites` で `codex --version` と (`CODEX_API_KEY` または `~/.codex/auth.json` 存在) をチェック。
+
+### `src/fixers/factory.ts` - インスタンス生成
+
+```typescript
+export function createFixer(config: Config): BugFixer {
+  switch (config.fixer) {
+    case "claude": return new ClaudeFixer(config.claudeModel);
+    case "codex":  return new CodexFixer(config.codexModel);
+    case "cursor": return new CursorFixer(config.cursorModel);
+  }
+}
+```
+
+### `src/fixers/outputParser.ts` - 共通出力パーサ
+
+現在 `src/fixGenerator.ts` の `extractSearchableText`, `parseCommitMessage`, `parseFixDetails` をここへ移動。Cursor (`json`) と Codex (`jsonl`) の構造化出力に対応:
+
+- Claude: text or JSONL (既存 `result` フィールド抽出ロジック)
+- Cursor: `--output-format json` の `result` フィールドを優先、フォールバックで stream-json の最終 assistant メッセージ
+- Codex: JSONL イベントから `agent_message_delta` / `agent_message` の結合、または `--output-last-message` ファイル参照
+
+`COMMIT_MSG:` と `FIX_DETAIL:` の抽出ロジックは全バックエンド共通。
+
+## 2. 既存ファイルの変更
+
+### `src/types.ts` - Config 拡張
+
+```typescript
+export type FixerKind = "claude" | "codex" | "cursor";
+
+export interface Config {
+  // ...既存フィールド
+  fixer: FixerKind;
+  claudeModel: string | null;
+  codexModel: string | null;
+  cursorModel: string | null;
+}
+```
+
+### `src/config.ts` - 環境変数パース追加
+
+新規 `AUTOFIX_FIXER` を**必須項目**として追加 (デフォルトなし)。`claude` / `codex` / `cursor` 以外はエラー。
+
+```typescript
+const fixer = parseFixerKind(process.env.AUTOFIX_FIXER);
+const codexModel  = process.env.AUTOFIX_CODEX_MODEL?.trim()  || null;
+const cursorModel = process.env.AUTOFIX_CURSOR_MODEL?.trim() || null;
+```
+
+### `src/fixGenerator.ts` - DI 化
+
+- コンストラクタで `BugFixer` を受け取り、フィールドとして保持
+- `runClaudeFix` を削除し、`this.fixer.generateFix({ cwd, prompt, timeoutMs })` を呼び出す
+- 出力パーサ (`parseCommitMessage`, `parseFixDetails`) は新規 `outputParser.ts` から import
+- `buildFixPrompt` などのコンテキスト構築ロジックは変更なし
+- `CLAUDE_TIMEOUT_MS` を `FIXER_TIMEOUT_MS` にリネーム (10分は据え置き)
+
+### `src/main.ts` - ファクトリ経由生成
+
+```typescript
+const fixer = createFixer(this.config);
+await fixer.verifyPrerequisites();
+this.fixGenerator = new FixGenerator(config, fixer);
+```
+
+既存の `verifyPrerequisites` 内の `claude --version` チェックは `fixer.verifyPrerequisites()` へ移譲。`git --version` チェックは残す。
+
+ログ出力の `claudeModel` フィールドも `fixer: config.fixer, model: <選択モデル>` に変更。
+
+## 3. ドキュメント・設定の更新
+
+### `.env.example` - 推奨設定明記
+
+```env
+# Backend selection (required): claude | codex | cursor
+# Recommended: cursor (no time-window limits, simple auth via CURSOR_API_KEY)
+AUTOFIX_FIXER=cursor
+
+# Cursor CLI settings (when AUTOFIX_FIXER=cursor)
+AUTOFIX_CURSOR_MODEL=auto       # auto | composer-2.5 | ...
+CURSOR_API_KEY=
+
+# Codex CLI settings (when AUTOFIX_FIXER=codex)
+AUTOFIX_CODEX_MODEL=gpt-5.3-codex
+CODEX_API_KEY=                  # or use ~/.codex/auth.json
+
+# Claude settings (when AUTOFIX_FIXER=claude) -- legacy
+AUTOFIX_CLAUDE_MODEL=
+CLAUDE_CODE_OAUTH_TOKEN=
+ANTHROPIC_API_KEY=
+```
+
+### `README.md` - 新セクション追加
+
+- **Backend Selection** セクション新設
+- 3バックエンドの比較表 (定額範囲、認証、利用上限)
+- 各CLIのインストール手順と認証手順
+- 推奨は Cursor を明示 (時間制限なし、定額内に収まりやすい)
+- アーキテクチャ図 (mermaid) を multi-backend に更新
+
+### `CLAUDE.md`, `AGENTS.md` - アーキ説明更新
+
+- `src/fixers/` の構造を追記
+- BugFixer インターフェース、Factory パターンを説明
+- 「Fix generation」セクションの記述を Claude 固定から「selected fixer」表現に変更
+
+## 4. テスト
+
+- `npm run typecheck` で全モジュールの型チェックを通過させる
+- `npm run build` で `dist/` 生成成功を確認
+- 実機テストは Cursor Pro 契約後にユーザーが実施 (現時点では型・ビルドのみ)
+
+## 5. Plan Mode 後の追加作業 (ユーザールール準拠)
+
+1. 新ブランチ `feature/multi-backend-fixer` を作成
+2. `.plans/multi-backend-fixer.plan.md` をブランチに push
+3. リポジトリに Issue 作成、plan.md リンクをコメント付与
+4. 実装完了後、`Closes #<issue>` を含む PR を作成
+
+## 制約・非対応事項
+
+- **本実装では実機の Cursor / Codex 動作確認は行わない** (ユーザーが Cursor Pro 契約後に検証)
+- バックエンド切替によるバグ修正の品質差分は別途検証 (本プランの範囲外)
+- フォールバック機構 (Cursor 枯渇時に Codex へ自動切替) は含まない (将来課題)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,10 @@ Guidelines for AI agents working on this codebase.
 ## Repository Purpose
 
 This is **Fixooly**, a daemon that automatically fixes bugs reported by
-Cursor Bugbot on GitHub PRs using Claude Code. It does NOT detect bugs itself;
-it only reads Cursor Bugbot review comments and generates fixes.
+Cursor Bugbot on GitHub PRs by delegating to a pluggable BugFixer backend
+(Cursor CLI / Codex CLI / Claude Code CLI), selected via the AUTOFIX_FIXER
+environment variable. It does NOT detect bugs itself; it only reads
+Cursor Bugbot review comments and generates fixes.
 
 ## Before Making Changes
 
@@ -37,15 +39,25 @@ it only reads Cursor Bugbot review comments and generates fixes.
            -> bugParser.ts
            -> githubClient.ts
            -> state.ts
+      -> fixers/factory.ts
+           -> fixers/claudeFixer.ts
+           -> fixers/codexFixer.ts
+           -> fixers/cursorFixer.ts
+                (all use fixers/spawnRunner.ts)
       -> fixGenerator.ts
+           -> fixers/types.ts (BugFixer)
+           -> fixers/outputParser.ts
       -> types.ts (shared by all)
 
 ## Key Interfaces
 
-- Config: All AUTOFIX_* settings from environment (appId, privateKey, etc.)
+- Config: All AUTOFIX_* settings from environment (appId, privateKey, fixer, ...)
+- FixerKind: "claude" | "codex" | "cursor" (the supported backends)
+- BugFixer: Common interface every fixer implements (name, verifyPrerequisites, generateFix)
+- FixerInput: Per-invocation input passed to a BugFixer (cwd, prompt, timeoutMs, bugCount)
 - BugbotBug: Parsed bug report from Cursor Bugbot comment
 - PrBugReport: A PR with its list of unprocessed bugs
-- FixResult: Commit SHA and list of fixed bugs after claude -p
+- FixResult: Commit SHA and list of fixed bugs after the fixer ran
 - PullRequest: GitHub PR metadata (owner, repo, number, headRef, etc.)
 - ReviewComment: Raw review comment data from GitHub API
 
@@ -58,11 +70,17 @@ After any code change:
 
 ## Environment Variables
 
-All config uses the AUTOFIX_ prefix. Required:
+All Fixooly-specific config uses the AUTOFIX_ prefix. Required:
 - AUTOFIX_APP_ID (GitHub App ID)
 - AUTOFIX_PRIVATE_KEY_PATH or AUTOFIX_PRIVATE_KEY (GitHub App private key)
+- AUTOFIX_FIXER (`claude` | `codex` | `cursor`; no default)
 
-Optional:
+Backend-specific (depending on AUTOFIX_FIXER):
+- cursor: CURSOR_API_KEY, optional AUTOFIX_CURSOR_MODEL
+- codex:  CODEX_API_KEY (or ~/.codex/auth.json), optional AUTOFIX_CODEX_MODEL
+- claude: CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY, optional AUTOFIX_CLAUDE_MODEL
+
+Optional general:
 - AUTOFIX_PUSH_TOKEN (classic PAT with repo scope, for triggering webhooks on push)
 
 Monitored repositories are auto-discovered from the App installations.
@@ -81,6 +99,15 @@ Monitored repositories are auto-discovered from the App installations.
   <!-- LOCATIONS START/END -->
 
 ### Changing fix generation behavior
-- Edit fixGenerator.ts, specifically runClaudeFix() for the prompt
-  and commitAndPush() for commit message format
-- The claude -p allowed tools are: Read, Edit, Bash(git diff *), Bash(git status *)
+- Edit fixGenerator.ts for the prompt construction in buildFixPrompt(),
+  and commitAndPush() for the commit message format
+- Per-backend CLI invocation lives in src/fixers/*Fixer.ts; tool
+  restrictions and authentication checks belong there, not in fixGenerator.ts
+- Shared output marker conventions (COMMIT_MSG:, FIX_DETAIL:) and parsing
+  live in src/fixers/outputParser.ts
+
+### Adding a new fixer backend
+1. Add the new value to FixerKind in types.ts and VALID_FIXER_KINDS in config.ts
+2. Create src/fixers/<name>Fixer.ts implementing the BugFixer interface
+3. Wire it into createFixer() in src/fixers/factory.ts
+4. Document env vars and authentication in .env.example and README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,10 @@ Instructions for Claude Code when working on this codebase.
 ## Project Overview
 
 Fixooly is a TypeScript daemon that monitors GitHub PRs for Cursor Bugbot
-review comments, parses bug reports, and auto-fixes them using Claude Code
-(claude -p). Fixes are committed directly to the PR head branch.
+review comments, parses bug reports, and auto-fixes them through a
+pluggable BugFixer backend (Cursor CLI / Codex CLI / Claude Code CLI),
+selected at startup via the AUTOFIX_FIXER environment variable.
+Fixes are committed directly to the PR head branch.
 
 ## Tech Stack
 
@@ -16,19 +18,31 @@ review comments, parses bug reports, and auto-fixes them using Claude Code
 - GitHub API: Octokit (via octokit package, GitHub App authentication)
 - State: SQLite (via better-sqlite3)
 - Config: dotenv
-- Fix generation: claude -p CLI with Read, Edit, Bash tools
+- Fix generation: pluggable BugFixer that wraps one of:
+  - Cursor CLI (`agent -p --force --trust --workspace --output-format json`) -- recommended
+  - OpenAI Codex CLI (`codex exec --sandbox workspace-write --ask-for-approval never --cd --json`)
+  - Anthropic Claude Code CLI (`claude -p --allowedTools ...`)
 
 ## Project Structure
 
     src/
-      main.ts              FixoolyDaemon entry point, polling loop
-      config.ts            AUTOFIX_* environment variable loader
-      types.ts             Shared interfaces (Config, BugbotBug, FixResult, PullRequest)
+      main.ts              FixoolyDaemon entry point, polling loop, fixer wiring
+      config.ts            AUTOFIX_* environment variable loader (incl. AUTOFIX_FIXER)
+      types.ts             Shared interfaces (Config, FixerKind, BugbotBug, ...)
       logger.ts            Structured logger with level support
       githubClient.ts      Octokit wrapper (GitHub App auth, PR list, review comments)
       bugbotMonitor.ts     Discovers unprocessed cursor[bot] bugs via App installations
       bugParser.ts         Parses Cursor Bugbot comment format into BugbotBug objects
-      fixGenerator.ts      Clones repo, runs claude -p, commits and pushes fixes
+      fixGenerator.ts      Clones repo, builds the prompt, delegates fix generation
+                           to the injected BugFixer, then commits and pushes
+      fixers/
+        types.ts           BugFixer interface and FixerInput type
+        factory.ts         createFixer(config) -- selects backend per AUTOFIX_FIXER
+        claudeFixer.ts     ClaudeFixer (claude -p with --allowedTools)
+        codexFixer.ts      CodexFixer (codex exec with workspace-write sandbox)
+        cursorFixer.ts     CursorFixer (agent -p with --force --trust --workspace)
+        spawnRunner.ts     Shared child-process runner (timeout, stdin, bounded stdout)
+        outputParser.ts    COMMIT_MSG / FIX_DETAIL marker parsing for text/JSON/JSONL
       state.ts             SQLite state tracking (processed_bugs table)
 
 ## Build and Run Commands
@@ -57,8 +71,12 @@ review comments, parses bug reports, and auto-fixes them using Claude Code
 - Repository discovery: auto-discovered from App installations (no manual repo/org list)
 - Bugbot comment parsing: Regex extraction of BUGBOT_BUG_ID, DESCRIPTION, and
   LOCATIONS markers from cursor[bot] review comments
-- Fix generation: claude -p is spawned as a child process with prompt piped via
-  stdin; allowed tools are Read, Edit, and limited Bash (git diff/status only)
+- Fix generation: dispatched to the selected BugFixer implementation. FixGenerator
+  builds a backend-agnostic prompt that asks the model to emit COMMIT_MSG: and
+  FIX_DETAIL: marker lines; src/fixers/outputParser.ts extracts those markers from
+  whichever output format the underlying CLI produces (plain text / single-object
+  JSON / JSONL stream). Each fixer enforces its own sandbox / allowed-tools policy
+  (Claude: --allowedTools; Codex: --sandbox workspace-write; Cursor: --trust + --force).
 - State: SQLite processed_bugs table with bug_id PRIMARY KEY prevents duplicates
 - Repo cloning: Repos cloned to {workDir}/{owner}/{repo}/; reused with git fetch
 - Git auth for clone/fetch: Installation access tokens via http.extraheader
@@ -69,9 +87,11 @@ review comments, parses bug reports, and auto-fixes them using Claude Code
 
 - The daemon processes PRs sequentially (single-threaded)
 - Bug parser depends on Cursor Bugbot comment format which may change
-- Fix generator has a 10-minute timeout for claude -p
+- Fix generator has a 10-minute timeout applied to whichever BugFixer is selected
 - Git operations have a 2-minute timeout
 - Fixes commit directly to the PR head branch (no separate fix branch)
 - No dependency on gh CLI or GH_TOKEN; authentication is via GitHub App
 - Optional AUTOFIX_PUSH_TOKEN (classic PAT) for git push to trigger webhooks
-- Environment variables use AUTOFIX_ prefix
+- Environment variables use AUTOFIX_ prefix; AUTOFIX_FIXER is required
+- Recommended backend for daemon use is `cursor` (no per-hour rate limit on
+  the Cursor Pro Auto+Composer pool); see README.md "Backend Selection"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # Fixooly
 
-Automatically fix [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot)-reported bugs using [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+Automatically fix [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot)-reported
+bugs using a pluggable AI coding CLI -- choose between
+[Cursor CLI](https://cursor.com/cli) (recommended),
+[OpenAI Codex CLI](https://developers.openai.com/codex/cli/reference), or
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 
-Monitors open pull requests for Cursor Bugbot review comments, parses bug reports, generates fixes via `claude -p`, and commits them directly to the PR head branch. A cost-effective alternative to Cursor's built-in Autofix.
+Monitors open pull requests for Cursor Bugbot review comments, parses bug reports, dispatches to the configured fixer to apply the fix, and commits the result directly to the PR head branch. A cost-effective alternative to Cursor's built-in Autofix.
 
 ## Features
 
 - **Cursor Bugbot monitoring**: Polls GitHub for `cursor[bot]` review comments using repo-level API for efficient scanning
 - **Resolved thread filtering**: Skips bugs whose review threads have been resolved (via GraphQL API)
 - **Automatic bug parsing**: Extracts title, severity, description, file path, and line numbers from Bugbot's structured comment format
-- **Claude Code fix generation**: Runs `claude -p` with Edit tools to fix detected bugs in cloned repositories
+- **Pluggable fix backend**: Switch between Cursor, Codex, and Claude CLIs via the `AUTOFIX_FIXER` environment variable
 - **Direct commit to PR**: Pushes fixes directly to the PR head branch (no separate fix branch or approval workflow)
 - **Duplicate prevention**: SQLite-based state tracking ensures each bug ID is processed only once
 - **Single-instance lock**: File-based lock prevents multiple daemon instances from running concurrently
@@ -20,7 +24,7 @@ Monitors open pull requests for Cursor Bugbot review comments, parses bug report
 ## Prerequisites
 
 - A [GitHub App](https://docs.github.com/en/apps/creating-github-apps) with required permissions, installed on target organizations/user accounts
-- **`claude` CLI**: Authenticated Claude Code (`claude --version`)
+- One of the supported fixer CLIs installed and authenticated (see [Backend Selection](#backend-selection))
 - **`git`**: For repository operations
 - **Node.js** >= 18.0.0 (for local installation) or **Docker** (for containerized deployment)
 
@@ -38,7 +42,51 @@ After creating the App:
 2. Generate and download a **private key** (`.pem` file)
 3. Install the App on the organizations/user accounts whose repositories you want to monitor
 
-### Claude Code Authentication
+## Backend Selection
+
+`AUTOFIX_FIXER` is required and chooses which CLI Fixooly uses to apply fixes. **Cursor is the recommended backend** for daemon use because Cursor Pro's Auto/Composer pool has no 5-hour rolling rate limit, unlike Codex on ChatGPT Plus/Pro.
+
+| Backend | Plan | Headless auth | Rate limits | Recommended |
+|---|---|---|---|---|
+| `cursor` | Cursor Pro ($20/mo) | `CURSOR_API_KEY` | Monthly Auto+Composer pool, no per-hour cap | **Yes** |
+| `codex`  | ChatGPT Plus ($20/mo) | `CODEX_API_KEY` or `~/.codex/auth.json` | 5-hour rolling + weekly cap | When you prefer GPT-5.3-Codex |
+| `claude` | Anthropic plan or pay-as-you-go | `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` | Per-plan limits | Legacy |
+
+### Cursor CLI (recommended)
+
+```bash
+# Install (macOS, Linux, WSL)
+curl https://cursor.com/install -fsS | bash
+
+# Verify
+agent --version
+
+# Authenticate for daemon use
+export CURSOR_API_KEY=...
+```
+
+Optional: override the model with `AUTOFIX_CURSOR_MODEL=auto` (cost-optimised router) or `AUTOFIX_CURSOR_MODEL=composer-2.5` (Cursor's own agentic coding model). Both draw from the Auto+Composer usage pool included in the Cursor Pro flat rate.
+
+### Codex CLI
+
+```bash
+# Install (see https://developers.openai.com/codex/cli/reference for full options)
+npm install -g @openai/codex
+
+# Verify
+codex --version
+
+# Authenticate (one of):
+#   a) API key
+export CODEX_API_KEY=...
+#   b) ChatGPT subscription (run on a machine with a browser, then copy)
+codex login --device-auth
+# copy ~/.codex/auth.json to the daemon host afterwards
+```
+
+Optional: override the model with `AUTOFIX_CODEX_MODEL=gpt-5.3-codex` (the coding-tuned default).
+
+### Claude Code CLI (legacy)
 
 #### Option 1: OAuth Token (`CLAUDE_CODE_OAUTH_TOKEN`) -- for Pro/Max/Team plan
 
@@ -86,9 +134,12 @@ git clone https://github.com/Senna46/fixooly.git
 cd fixooly
 
 cp .env.example .env
-# Edit .env with your GitHub App credentials and Claude auth
+# Edit .env with your GitHub App credentials, the AUTOFIX_FIXER backend,
+# and the corresponding API key (CURSOR_API_KEY / CODEX_API_KEY /
+# CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY).
 
-# Prevent Docker from creating ~/.claude.json as a directory
+# (Claude only) Prevent Docker from creating ~/.claude.json as a directory
+# when AUTOFIX_FIXER=claude.
 touch ~/.claude.json
 
 docker compose build
@@ -124,15 +175,25 @@ Monitored repositories are auto-discovered from the GitHub App installations.
 | `AUTOFIX_POLL_INTERVAL` | No | `120` | Polling interval in seconds |
 | `AUTOFIX_WORK_DIR` | No | `~/.fixooly/repos` | Directory for cloning repositories |
 | `AUTOFIX_DB_PATH` | No | `~/.fixooly/state.db` | SQLite database path |
-| `AUTOFIX_CLAUDE_MODEL` | No | CLI default | Claude model to use |
 | `AUTOFIX_LOG_LEVEL` | No | `info` | Log level (debug/info/warn/error) |
 
-### Claude Authentication
+### Fixer Backend
 
-| Variable | Required | Description |
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `AUTOFIX_FIXER` | **Yes** | _(none)_ | `claude` / `codex` / `cursor` (no default; must opt in explicitly) |
+| `AUTOFIX_CURSOR_MODEL` | No | CLI default | Model override when `AUTOFIX_FIXER=cursor` (e.g. `auto`, `composer-2.5`) |
+| `AUTOFIX_CODEX_MODEL` | No | CLI default | Model override when `AUTOFIX_FIXER=codex` (e.g. `gpt-5.3-codex`) |
+| `AUTOFIX_CLAUDE_MODEL` | No | CLI default | Model override when `AUTOFIX_FIXER=claude` |
+
+### Fixer Authentication
+
+| Variable | Applies to | Description |
 |---|---|---|
-| `CLAUDE_CODE_OAUTH_TOKEN` | macOS Docker only | Claude OAuth token (`claude setup-token`) |
-| `ANTHROPIC_API_KEY` | Alternative | Anthropic API key for pay-as-you-go billing |
+| `CURSOR_API_KEY` | `cursor` | Cursor CLI API key for headless / daemon use |
+| `CODEX_API_KEY` | `codex` | OpenAI Codex CLI API key (alternative: `~/.codex/auth.json`) |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude` | Claude OAuth token (`claude setup-token`) |
+| `ANTHROPIC_API_KEY` | `claude` | Anthropic API key for pay-as-you-go billing |
 
 ## Architecture
 
@@ -148,8 +209,8 @@ flowchart TD
     HasBugs -->|No| Sleep[Sleep poll interval]
     HasBugs -->|Yes| FetchPR[Fetch PR details, skip closed PRs]
     FetchPR --> Clone[Clone/fetch repo, checkout PR head branch]
-    Clone --> Claude["Run claude -p with Edit tools"]
-    Claude --> Changes{Changes made?}
+    Clone --> Fixer["Dispatch to selected BugFixer (claude / codex / cursor)"]
+    Fixer --> Changes{Changes made?}
     Changes -->|No| Record[Record bugs as processed]
     Changes -->|Yes| Commit[git add + commit + push to PR head]
     Commit --> PostComment[Post fix summary comment on PR]
@@ -163,13 +224,20 @@ flowchart TD
 | Module | Responsibility |
 |---|---|
 | `main.ts` | `FixoolyDaemon` polling loop, graceful shutdown, single-instance lock |
-| `config.ts` | Loads and validates `AUTOFIX_*` environment variables |
+| `config.ts` | Loads and validates `AUTOFIX_*` environment variables (incl. `AUTOFIX_FIXER`) |
 | `bugbotMonitor.ts` | Efficient repo-level scanning, resolved thread filtering, bug discovery |
 | `bugParser.ts` | Parses `cursor[bot]` comment bodies into structured `BugbotBug` objects |
-| `fixGenerator.ts` | Clones repos, runs `claude -p`, commits and pushes fixes |
+| `fixGenerator.ts` | Clones repos, builds the prompt, delegates fix generation to the injected `BugFixer`, then commits and pushes |
+| `fixers/types.ts` | `BugFixer` interface and `FixerKind` definitions |
+| `fixers/factory.ts` | `createFixer(config)` -- selects the implementation matching `AUTOFIX_FIXER` |
+| `fixers/claudeFixer.ts` | Claude Code CLI (`claude -p`) backend with `--allowedTools` restrictions |
+| `fixers/codexFixer.ts` | OpenAI Codex CLI (`codex exec`) backend with `--sandbox workspace-write` |
+| `fixers/cursorFixer.ts` | Cursor CLI (`agent -p`) backend with `--force --trust` for headless use |
+| `fixers/spawnRunner.ts` | Shared child-process runner (timeout, stdin piping, bounded stdout) |
+| `fixers/outputParser.ts` | Extracts `COMMIT_MSG:` / `FIX_DETAIL:` markers from any backend's stdout (text / JSON / JSONL) |
 | `githubClient.ts` | Octokit wrapper: GitHub App auth, repo-level comments, GraphQL threads, PR details |
 | `state.ts` | SQLite tracking of processed bug IDs to prevent duplicates |
-| `types.ts` | Shared TypeScript interfaces |
+| `types.ts` | Shared TypeScript interfaces (incl. `Config` and `FixerKind`) |
 | `logger.ts` | Structured logging with configurable levels |
 
 ## Running as a Service

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,9 +11,10 @@ import { config as dotenvConfig } from "dotenv";
 import { homedir } from "os";
 import { join } from "path";
 
-import type { Config, LogLevel } from "./types.js";
+import type { Config, FixerKind, LogLevel } from "./types.js";
 
 const VALID_LOG_LEVELS: LogLevel[] = ["debug", "info", "warn", "error"];
+const VALID_FIXER_KINDS: FixerKind[] = ["claude", "codex", "cursor"];
 
 export function loadConfig(): Config {
   dotenvConfig();
@@ -45,7 +46,10 @@ export function loadConfig(): Config {
   const dbPath = process.env.AUTOFIX_DB_PATH?.trim() || defaultDbPath;
 
   const pushToken = process.env.AUTOFIX_PUSH_TOKEN?.trim() || null;
+  const fixer = parseFixerKind(process.env.AUTOFIX_FIXER);
   const claudeModel = process.env.AUTOFIX_CLAUDE_MODEL?.trim() || null;
+  const codexModel = process.env.AUTOFIX_CODEX_MODEL?.trim() || null;
+  const cursorModel = process.env.AUTOFIX_CURSOR_MODEL?.trim() || null;
   const logLevel = parseLogLevel(process.env.AUTOFIX_LOG_LEVEL);
 
   return {
@@ -55,7 +59,10 @@ export function loadConfig(): Config {
     pollInterval,
     workDir,
     dbPath,
+    fixer,
     claudeModel,
+    codexModel,
+    cursorModel,
     logLevel,
   };
 }
@@ -108,4 +115,24 @@ function parseLogLevel(value: string | undefined): LogLevel {
     );
   }
   return level;
+}
+
+// AUTOFIX_FIXER is mandatory and intentionally has no default. Operators
+// must opt into a backend explicitly so they understand which CLI and
+// subscription is being charged.
+function parseFixerKind(value: string | undefined): FixerKind {
+  const raw = value?.trim().toLowerCase();
+  if (!raw) {
+    throw new Error(
+      "Configuration error: AUTOFIX_FIXER is required. " +
+        `Set it to one of: ${VALID_FIXER_KINDS.join(", ")}.`
+    );
+  }
+  if (!VALID_FIXER_KINDS.includes(raw as FixerKind)) {
+    throw new Error(
+      `Configuration error: Invalid AUTOFIX_FIXER value "${value}". ` +
+        `Valid values: ${VALID_FIXER_KINDS.join(", ")}.`
+    );
+  }
+  return raw as FixerKind;
 }

--- a/src/fixGenerator.ts
+++ b/src/fixGenerator.ts
@@ -1,20 +1,31 @@
 // Fix generation module for Fixooly.
 // Clones the target repository locally, checks out the PR head branch,
-// runs claude -p with edit and exploration tools to fix detected Cursor Bugbot bugs,
-// then commits and pushes the fix directly to the PR head branch.
-// Uses GitHub App installation tokens for git authentication.
-// Includes project structure, documentation, PR diff, changed file contents,
-// and related file imports as context for accurate, well-integrated fixes.
-// Limitations: Requires git CLI. Claude may not fix all bugs or may
-//   introduce new issues. Only one fix generation runs at a time per PR.
+// dispatches to the configured BugFixer (Claude / Codex / Cursor CLI) to
+// edit files in place, then commits and pushes the fix directly to the
+// PR head branch. Uses GitHub App installation tokens for git
+// authentication.
+// Includes project structure, documentation, PR diff, changed file
+// contents, and related file imports as context for accurate,
+// well-integrated fixes. The fixer-specific CLI invocation lives in
+// src/fixers/*; this module is concerned with cloning, prompt assembly,
+// and committing the result.
+// Limitations: Requires git CLI. The underlying fixer may not resolve
+//   every bug or may introduce new issues. Only one fix generation runs
+//   at a time per PR.
 
-import { execFile, spawn } from "child_process";
+import { execFile } from "child_process";
 import { existsSync } from "fs";
-import { readFile } from "fs/promises";
-import { mkdir } from "fs/promises";
+import { readFile, mkdir } from "fs/promises";
 import { dirname, join, resolve as pathResolve } from "path";
 import { promisify } from "util";
 
+import {
+  COMMIT_MSG_PREFIX,
+  FIX_DETAIL_PREFIX,
+  parseCommitMessage,
+  parseFixDetails,
+} from "./fixers/outputParser.js";
+import type { BugFixer } from "./fixers/types.js";
 import { logger } from "./logger.js";
 import type { BugbotBug, Config, FixResult, PullRequest } from "./types.js";
 
@@ -26,39 +37,22 @@ const MAX_DOC_SIZE = 10_000;
 
 const PROJECT_DOC_FILES = ["CLAUDE.md", "AGENTS.md", "README.md"];
 
-const ALLOWED_TOOLS = [
-  "Read",
-  "Edit",
-  "Bash(git diff *)",
-  "Bash(git status *)",
-  "Bash(find *)",
-  "Bash(grep *)",
-  "Bash(rg *)",
-  "Bash(ls *)",
-  "Bash(cat *)",
-  "Bash(head *)",
-  "Bash(tail *)",
-  "Bash(wc *)",
-  "Bash(tree *)",
-].join(",");
-
-const COMMIT_MSG_PREFIX = "COMMIT_MSG: ";
-const FIX_DETAIL_PREFIX = "FIX_DETAIL: ";
-
-const CLAUDE_TIMEOUT_MS = 10 * 60 * 1000;
-const SIGKILL_GRACE_MS = 5_000;
-const MAX_STDOUT_SIZE = 100_000;
+// Wall-clock budget for a single fix generation. Applies uniformly to
+// every BugFixer backend; the runner in spawnRunner.ts enforces it.
+const FIXER_TIMEOUT_MS = 10 * 60 * 1000;
 
 const execFileAsync = promisify(execFile);
 
 export class FixGenerator {
   private config: Config;
+  private fixer: BugFixer;
   private currentGitToken: string | null = null;
   private botName: string = "fixooly[bot]";
   private botEmail: string = "fixooly[bot]@users.noreply.github.com";
 
-  constructor(config: Config) {
+  constructor(config: Config, fixer: BugFixer) {
     this.config = config;
+    this.fixer = fixer;
   }
 
   setBotIdentity(appSlug: string, botUserId: number): void {
@@ -108,19 +102,23 @@ export class FixGenerator {
         relatedFileContents
       );
 
-      const claudeOutput = await this.runClaudeFix(
-        repoDir,
+      const fixerOutput = await this.fixer.generateFix({
+        cwd: repoDir,
         prompt,
-        bugs.length
-      );
+        timeoutMs: FIXER_TIMEOUT_MS,
+        bugCount: bugs.length,
+      });
 
       const hasChanges = await this.hasUncommittedChanges(repoDir);
       if (!hasChanges) {
-        logger.info("Claude did not make any changes. No fix to commit.");
+        logger.info(
+          `${this.fixer.name} fixer did not make any changes. ` +
+            "No fix to commit."
+        );
         return null;
       }
 
-      const commitSummary = parseCommitMessage(claudeOutput);
+      const commitSummary = parseCommitMessage(fixerOutput);
       const commitSha = await this.commitAndPush(
         repoDir,
         pr.headRef,
@@ -128,7 +126,7 @@ export class FixGenerator {
         commitSummary
       );
 
-      const fixDetails = parseFixDetails(claudeOutput);
+      const fixDetails = parseFixDetails(fixerOutput);
       const fixedBugs = bugs.map((bug) => ({
         bugId: bug.bugId,
         title: bug.title,
@@ -200,7 +198,7 @@ export class FixGenerator {
     pr: PullRequest
   ): Promise<void> {
     // Discard any leftover changes from a previous run (e.g. crash after
-    // claude -p edited files but before commit/push completed).
+    // the fixer edited files but before commit/push completed).
     await this.execGit(repoDir, ["reset", "--hard", "HEAD"]);
     await this.execGit(repoDir, ["clean", "-fd"]);
 
@@ -304,106 +302,6 @@ export class FixGenerator {
     );
 
     return sections.join("\n\n");
-  }
-
-  // ============================================================
-  // Run claude -p for fixing bugs
-  // ============================================================
-
-  private async runClaudeFix(
-    repoDir: string,
-    prompt: string,
-    bugCount: number
-  ): Promise<string> {
-    const args = ["-p", "--allowedTools", ALLOWED_TOOLS];
-
-    if (this.config.claudeModel) {
-      args.push("--model", this.config.claudeModel);
-    }
-
-    logger.info("Running claude -p for fix generation...", {
-      bugCount,
-      repoDir,
-    });
-
-    return new Promise<string>((resolve, reject) => {
-      let settled = false;
-
-      const child = spawn("claude", args, {
-        cwd: repoDir,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-
-      let stdout = "";
-      let stderr = "";
-
-      const killTimer = setTimeout(() => {
-        if (settled) return;
-        logger.warn("claude -p timed out, sending SIGTERM.", {
-          timeoutMs: CLAUDE_TIMEOUT_MS,
-        });
-        child.kill("SIGTERM");
-        setTimeout(() => {
-          if (settled) return;
-          logger.warn("claude -p did not exit after SIGTERM, sending SIGKILL.");
-          child.kill("SIGKILL");
-        }, SIGKILL_GRACE_MS);
-      }, CLAUDE_TIMEOUT_MS);
-
-      child.stdout.on("data", (data: Buffer) => {
-        stdout += data.toString();
-        if (stdout.length > MAX_STDOUT_SIZE) {
-          stdout = stdout.substring(stdout.length - MAX_STDOUT_SIZE);
-        }
-      });
-
-      child.stderr.on("data", (data: Buffer) => {
-        stderr += data.toString();
-      });
-
-      child.on("close", (code, signal) => {
-        clearTimeout(killTimer);
-        if (settled) return;
-        settled = true;
-
-        if (signal === "SIGTERM" || signal === "SIGKILL") {
-          logger.error("claude -p timed out.", {
-            signal,
-            timeoutMs: CLAUDE_TIMEOUT_MS,
-            stderr: stderr.substring(0, 1000) || "(empty)",
-            stdoutTail: stdout.substring(Math.max(0, stdout.length - 1000)) || "(empty)",
-          });
-          reject(
-            new Error(
-              `claude -p fix generation timed out after ${CLAUDE_TIMEOUT_MS / 1000}s.`
-            )
-          );
-          return;
-        }
-        if (code !== 0) {
-          logger.error("claude -p exited with non-zero code.", {
-            exitCode: code,
-            stderr: stderr.substring(0, 1000) || "(empty)",
-            stdoutTail: stdout.substring(Math.max(0, stdout.length - 2000)) || "(empty)",
-          });
-          reject(
-            new Error(`claude -p fix generation exited with code ${code}.`)
-          );
-          return;
-        }
-        resolve(stdout);
-      });
-
-      child.on("error", (error) => {
-        clearTimeout(killTimer);
-        if (settled) return;
-        settled = true;
-        reject(new Error(`claude -p fix generation failed: ${error.message}`));
-      });
-
-      child.stdin.write(prompt);
-      child.stdin.end();
-    });
   }
 
   // ============================================================
@@ -864,90 +762,6 @@ function safeResolvePath(baseDir: string, relativePath: string): string | null {
     return null;
   }
   return resolved;
-}
-
-// ============================================================
-// Utility: extract searchable text from claude -p output
-// ============================================================
-
-function extractSearchableText(claudeOutput: string): string {
-  const trimmed = claudeOutput.trim();
-  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-    try {
-      const parsed = JSON.parse(trimmed);
-      if (typeof parsed.result === "string") {
-        return parsed.result;
-      }
-    } catch {
-      // fall through to JSONL line scanning
-    }
-  }
-
-  // Try JSONL: find the last line with a result field.
-  // This also handles truncated output where the leading { or [ was stripped,
-  // since individual JSONL lines near the end remain intact.
-  const jsonLines = trimmed.split("\n");
-  for (let i = jsonLines.length - 1; i >= 0; i--) {
-    const line = jsonLines[i].trim();
-    if (!line.startsWith("{")) continue;
-    try {
-      const parsed = JSON.parse(line);
-      if (typeof parsed.result === "string") {
-        return parsed.result;
-      }
-    } catch {
-      continue;
-    }
-  }
-
-  return claudeOutput;
-}
-
-// ============================================================
-// Utility: parse COMMIT_MSG from claude -p output
-// ============================================================
-
-function parseCommitMessage(claudeOutput: string): string | null {
-  const textToSearch = extractSearchableText(claudeOutput);
-
-  const lines = textToSearch.split("\n");
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i].trim();
-    if (line.startsWith(COMMIT_MSG_PREFIX)) {
-      const message = line.substring(COMMIT_MSG_PREFIX.length).trim();
-      if (message.length > 0) {
-        return message;
-      }
-    }
-  }
-
-  return null;
-}
-
-// ============================================================
-// Utility: parse per-bug FIX_DETAIL lines from claude -p output
-// ============================================================
-
-function parseFixDetails(claudeOutput: string): Map<string, string> {
-  const details = new Map<string, string>();
-  const textToSearch = extractSearchableText(claudeOutput);
-
-  for (const line of textToSearch.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed.startsWith(FIX_DETAIL_PREFIX)) {
-      const content = trimmed.substring(FIX_DETAIL_PREFIX.length).trim();
-      const separatorIndex = content.indexOf("|");
-      if (separatorIndex > 0) {
-        const bugId = content.substring(0, separatorIndex).trim();
-        const fixDescription = content.substring(separatorIndex + 1).trim();
-        if (bugId && fixDescription) {
-          details.set(bugId, fixDescription);
-        }
-      }
-    }
-  }
-
-  return details;
 }
 
 // ============================================================

--- a/src/fixers/claudeFixer.ts
+++ b/src/fixers/claudeFixer.ts
@@ -1,0 +1,104 @@
+// ClaudeFixer: BugFixer implementation backed by the Anthropic Claude
+// Code CLI (`claude -p`). Uses --allowedTools to restrict the agent to
+// Read/Edit and a small set of read-only Bash commands so it cannot run
+// arbitrary shell commands during fix generation.
+// Authentication: relies on Claude Code's own credential resolution
+// (CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, or ~/.claude/.credentials.json).
+// Limitations: Requires the claude binary on PATH. Fix quality is
+//   inherited from whichever model Claude Code selects (or whatever
+//   AUTOFIX_CLAUDE_MODEL overrides it to).
+
+import { execFile } from "child_process";
+import { existsSync } from "fs";
+import { promisify } from "util";
+
+import { logger } from "../logger.js";
+import { runFixerProcess } from "./spawnRunner.js";
+import type { BugFixer, FixerInput, FixerKind } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+// Tools claude -p is allowed to invoke. Edit is the main file-mutation
+// capability; the bash entries are limited to read-only or inspection
+// commands so the agent cannot run arbitrary scripts.
+const ALLOWED_TOOLS = [
+  "Read",
+  "Edit",
+  "Bash(git diff *)",
+  "Bash(git status *)",
+  "Bash(find *)",
+  "Bash(grep *)",
+  "Bash(rg *)",
+  "Bash(ls *)",
+  "Bash(cat *)",
+  "Bash(head *)",
+  "Bash(tail *)",
+  "Bash(wc *)",
+  "Bash(tree *)",
+].join(",");
+
+// Upper bound on the amount of stdout we keep in memory. Claude's --print
+// mode emits the final JSON result at the end, so retaining only the tail
+// is sufficient for parsing.
+const MAX_STDOUT_SIZE = 100_000;
+
+export class ClaudeFixer implements BugFixer {
+  readonly name: FixerKind = "claude";
+  private readonly model: string | null;
+
+  constructor(model: string | null) {
+    this.model = model;
+  }
+
+  async verifyPrerequisites(): Promise<void> {
+    try {
+      const { stdout } = await execFileAsync("claude", ["--version"]);
+      logger.debug("claude CLI detected.", { version: stdout.trim() });
+    } catch {
+      throw new Error(
+        "claude CLI is not available. Install Claude Code first: " +
+          "https://docs.anthropic.com/en/docs/claude-code"
+      );
+    }
+
+    if (
+      !process.env.CLAUDE_CODE_OAUTH_TOKEN &&
+      !process.env.ANTHROPIC_API_KEY
+    ) {
+      const homeDir = process.env.HOME ?? "/root";
+      const credFile = `${homeDir}/.claude/.credentials.json`;
+      if (!existsSync(credFile)) {
+        logger.warn(
+          "No Claude authentication detected. " +
+            "On macOS Docker, set CLAUDE_CODE_OAUTH_TOKEN " +
+            "(run 'claude setup-token' to generate). " +
+            "On Linux, ensure ~/.claude is mounted and contains .credentials.json."
+        );
+      }
+    }
+  }
+
+  async generateFix(input: FixerInput): Promise<string> {
+    const args = ["-p", "--allowedTools", ALLOWED_TOOLS];
+
+    if (this.model) {
+      args.push("--model", this.model);
+    }
+
+    logger.info("Running claude -p for fix generation...", {
+      bugCount: input.bugCount,
+      repoDir: input.cwd,
+      model: this.model ?? "(default)",
+    });
+
+    return runFixerProcess({
+      binary: "claude",
+      args,
+      cwd: input.cwd,
+      stdinInput: input.prompt,
+      timeoutMs: input.timeoutMs,
+      logTag: "claude -p",
+      maxStdoutSize: MAX_STDOUT_SIZE,
+    });
+  }
+}

--- a/src/fixers/codexFixer.ts
+++ b/src/fixers/codexFixer.ts
@@ -1,0 +1,109 @@
+// CodexFixer: BugFixer implementation backed by the OpenAI Codex CLI
+// (`codex exec`). Configured for fully unattended use:
+//   * --sandbox workspace-write: confine file edits to the cloned repo,
+//     equivalent in intent to Claude's --allowedTools=Edit + read-only Bash.
+//   * --ask-for-approval never: never pause for human approval.
+//   * --skip-git-repo-check: Fixooly already clones into a git repo, but
+//     this flag protects against transient detection issues (e.g. when
+//     running inside a worktree the CLI does not recognise).
+//   * --cd: pin the agent to the cloned repository directory.
+//   * --json: emit a JSONL event stream so the shared output parser can
+//     either pull last_agent_message or concatenate streaming deltas.
+// Authentication: CODEX_API_KEY is the simplest option for daemon/CI
+// use. ChatGPT-managed authentication via ~/.codex/auth.json is also
+// supported but requires copying the file from an interactive machine.
+// Limitations: ChatGPT Plus/Pro plans enforce a 5-hour rolling rate limit
+//   (plus a weekly cap) on the underlying models, which can interrupt
+//   long polling daemons. Cursor is generally a better fit for 24/7
+//   daemons -- see plan in .plans/ for the trade-off discussion.
+
+import { execFile } from "child_process";
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { promisify } from "util";
+
+import { logger } from "../logger.js";
+import { runFixerProcess } from "./spawnRunner.js";
+import type { BugFixer, FixerInput, FixerKind } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+const CODEX_BINARY = "codex";
+
+// Codex's JSONL event stream is more verbose than Claude's --print
+// output, so we retain a larger tail.
+const MAX_STDOUT_SIZE = 300_000;
+
+export class CodexFixer implements BugFixer {
+  readonly name: FixerKind = "codex";
+  private readonly model: string | null;
+
+  constructor(model: string | null) {
+    this.model = model;
+  }
+
+  async verifyPrerequisites(): Promise<void> {
+    try {
+      const { stdout } = await execFileAsync(CODEX_BINARY, ["--version"]);
+      logger.debug("Codex CLI detected.", { version: stdout.trim() });
+    } catch {
+      throw new Error(
+        `Codex CLI binary "${CODEX_BINARY}" is not available. ` +
+          "Install via npm (-g @openai/codex) or follow the official " +
+          "installation guide at https://developers.openai.com/codex/cli"
+      );
+    }
+
+    if (!process.env.CODEX_API_KEY) {
+      const authFile = join(homedir(), ".codex", "auth.json");
+      if (!existsSync(authFile)) {
+        logger.warn(
+          "No Codex authentication detected. Set CODEX_API_KEY for daemon " +
+            "use, or run 'codex login --device-auth' on a machine with a " +
+            `browser and copy ~/.codex/auth.json to ${authFile}.`
+        );
+      } else {
+        logger.debug("Using Codex auth.json for authentication.", {
+          authFile,
+        });
+      }
+    }
+  }
+
+  async generateFix(input: FixerInput): Promise<string> {
+    const args = [
+      "exec",
+      "--sandbox",
+      "workspace-write",
+      "--ask-for-approval",
+      "never",
+      "--skip-git-repo-check",
+      "--cd",
+      input.cwd,
+      "--json",
+    ];
+
+    if (this.model) {
+      args.push("--model", this.model);
+    }
+
+    logger.info("Running codex exec for fix generation...", {
+      bugCount: input.bugCount,
+      repoDir: input.cwd,
+      model: this.model ?? "(default)",
+    });
+
+    // codex exec reads the prompt from stdin when no positional prompt
+    // argument is provided, matching the pattern used for claude -p.
+    return runFixerProcess({
+      binary: CODEX_BINARY,
+      args,
+      cwd: input.cwd,
+      stdinInput: input.prompt,
+      timeoutMs: input.timeoutMs,
+      logTag: "codex exec",
+      maxStdoutSize: MAX_STDOUT_SIZE,
+    });
+  }
+}

--- a/src/fixers/cursorFixer.ts
+++ b/src/fixers/cursorFixer.ts
@@ -1,0 +1,125 @@
+// CursorFixer: BugFixer implementation backed by the Cursor CLI
+// (`agent -p`). Configured for fully unattended use in a daemon:
+//   * --force / --yolo equivalent: pre-approve every command including
+//     file modifications, so the agent does not block waiting for input.
+//   * --trust: trust the workspace without prompting (required in headless
+//     mode where there is no UI to confirm trust).
+//   * --workspace: pin the agent to the cloned repository directory.
+//   * --output-format json: emit a single JSON object so the shared output
+//     parser can pull the result string out reliably.
+// Authentication: CURSOR_API_KEY is the only required environment
+// variable for daemon/CI use. Interactive `agent login` also works, but
+// is generally unsuitable for unattended deployments.
+// Limitations: The Cursor CLI accepts the prompt as a trailing positional
+//   argument. On systems with small ARG_MAX, very large prompts may
+//   exceed the OS limit. Fixooly's prompt builder already enforces upper
+//   bounds on diff/file context sizes, but extreme cases may still hit
+//   E2BIG; if that happens, lower MAX_FILE_CONTEXT_SIZE in fixGenerator.
+
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+import { logger } from "../logger.js";
+import { runFixerProcess } from "./spawnRunner.js";
+import type { BugFixer, FixerInput, FixerKind } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+// Cursor CLI's installer (curl https://cursor.com/install -fsS | bash)
+// places an `agent` binary on PATH. Some distributions expose the same
+// tool as `cursor-agent` instead, so verifyPrerequisites tries both.
+const PRIMARY_BINARY = "agent";
+const FALLBACK_BINARY = "cursor-agent";
+
+// JSON wrapper inflates the assistant message somewhat, so the cap is
+// a little higher than Claude's 100KB tail.
+const MAX_STDOUT_SIZE = 200_000;
+
+export class CursorFixer implements BugFixer {
+  readonly name: FixerKind = "cursor";
+  private readonly model: string | null;
+  // Cached after verifyPrerequisites picks the binary that responded to
+  // --version. Defaults to the documented "agent" name until we confirm.
+  private resolvedBinary: string = PRIMARY_BINARY;
+
+  constructor(model: string | null) {
+    this.model = model;
+  }
+
+  async verifyPrerequisites(): Promise<void> {
+    const candidate = await this.detectBinary();
+    if (!candidate) {
+      throw new Error(
+        `Cursor CLI binary is not available (tried "${PRIMARY_BINARY}" and ` +
+          `"${FALLBACK_BINARY}"). Install via: ` +
+          "curl https://cursor.com/install -fsS | bash"
+      );
+    }
+    this.resolvedBinary = candidate.binary;
+    logger.debug("Cursor CLI detected.", {
+      binary: candidate.binary,
+      version: candidate.version,
+    });
+
+    if (!process.env.CURSOR_API_KEY) {
+      logger.warn(
+        "CURSOR_API_KEY is not set. The Cursor CLI will fall back to an " +
+          "interactive login session, which is unsuitable for daemon use. " +
+          "Run 'agent login' once or set CURSOR_API_KEY explicitly."
+      );
+    }
+  }
+
+  async generateFix(input: FixerInput): Promise<string> {
+    const args = [
+      "-p",
+      "--force",
+      "--trust",
+      "--workspace",
+      input.cwd,
+      "--output-format",
+      "json",
+    ];
+
+    if (this.model) {
+      args.push("--model", this.model);
+    }
+
+    // Cursor CLI reads the prompt as the trailing positional argument
+    // rather than from stdin, so we pass it via argv here.
+    args.push(input.prompt);
+
+    logger.info("Running Cursor CLI (agent -p) for fix generation...", {
+      bugCount: input.bugCount,
+      repoDir: input.cwd,
+      model: this.model ?? "(default)",
+      binary: this.resolvedBinary,
+    });
+
+    return runFixerProcess({
+      binary: this.resolvedBinary,
+      args,
+      cwd: input.cwd,
+      stdinInput: "",
+      timeoutMs: input.timeoutMs,
+      logTag: `${this.resolvedBinary} -p`,
+      maxStdoutSize: MAX_STDOUT_SIZE,
+    });
+  }
+
+  // Try the documented "agent" name first and fall back to "cursor-agent"
+  // for setups where the installer or a wrapper script used that name.
+  private async detectBinary(): Promise<
+    { binary: string; version: string } | null
+  > {
+    for (const binary of [PRIMARY_BINARY, FALLBACK_BINARY]) {
+      try {
+        const { stdout } = await execFileAsync(binary, ["--version"]);
+        return { binary, version: stdout.trim() };
+      } catch {
+        // try the next candidate
+      }
+    }
+    return null;
+  }
+}

--- a/src/fixers/factory.ts
+++ b/src/fixers/factory.ts
@@ -1,0 +1,33 @@
+// Factory that selects and instantiates the BugFixer implementation
+// corresponding to AUTOFIX_FIXER. Centralises the switch so that
+// main.ts does not need to import every concrete fixer class.
+// Limitations: Validation of the FixerKind value happens in config.ts
+//   via parseFixerKind(); this factory assumes its input has already
+//   been validated and simply throws on the unreachable default branch.
+
+import type { Config } from "../types.js";
+import { ClaudeFixer } from "./claudeFixer.js";
+import { CodexFixer } from "./codexFixer.js";
+import { CursorFixer } from "./cursorFixer.js";
+import type { BugFixer } from "./types.js";
+
+// Build the BugFixer matching the selected backend kind in the Config.
+// Throws if the value is not one of the supported kinds (defensive check
+// against future enum expansions that forget to update this factory).
+export function createFixer(config: Config): BugFixer {
+  switch (config.fixer) {
+    case "claude":
+      return new ClaudeFixer(config.claudeModel);
+    case "codex":
+      return new CodexFixer(config.codexModel);
+    case "cursor":
+      return new CursorFixer(config.cursorModel);
+    default: {
+      const exhaustiveCheck: never = config.fixer;
+      throw new Error(
+        `Unsupported AUTOFIX_FIXER value: "${exhaustiveCheck}". ` +
+          'Expected one of "claude", "codex", or "cursor".'
+      );
+    }
+  }
+}

--- a/src/fixers/outputParser.ts
+++ b/src/fixers/outputParser.ts
@@ -1,0 +1,192 @@
+// Common parser for CLI stdout produced by any BugFixer implementation.
+// Supports three families of output formats:
+//   * Plain text (Claude --print=text, Codex default formatted output)
+//   * Single JSON object with a `result` string field (Claude --print, Cursor --output-format json)
+//   * Newline-delimited JSON streams (Cursor --output-format stream-json, Codex --json)
+// The parser first heuristically extracts the natural-language assistant
+// text from the raw stdout, then scans that text for COMMIT_MSG: and
+// FIX_DETAIL: marker lines that the fixers' prompt asks the model to emit.
+// Limitations: When a backend wraps the assistant text in an unknown
+//   structure, the parser falls back to the raw output so marker lines
+//   still match as long as they appear verbatim in stdout.
+
+// Marker prefixes that the shared prompt asks every backend to emit.
+// fixGenerator.ts uses these to build the prompt, and the parser scans
+// for them in the captured stdout.
+export const COMMIT_MSG_PREFIX = "COMMIT_MSG: ";
+export const FIX_DETAIL_PREFIX = "FIX_DETAIL: ";
+
+// Public entry: extract the assistant text from an arbitrary CLI stdout.
+// Used directly by tests and indirectly by the marker parsers below.
+export function extractSearchableText(rawOutput: string): string {
+  const trimmed = rawOutput.trim();
+  if (trimmed.length === 0) {
+    return rawOutput;
+  }
+
+  // Case 1: single JSON object/array (Claude --print, Cursor --output-format json)
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      const direct = extractMessageFromJson(parsed);
+      if (direct) {
+        return direct;
+      }
+    } catch {
+      // fall through to JSONL scanning
+    }
+  }
+
+  // Case 2: JSONL stream - first try to find a terminal message with
+  // a complete result/last_agent_message field (Cursor stream-json's
+  // final "result" line, Codex's task_complete event).
+  const lines = trimmed.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (!line.startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(line);
+      const text = extractMessageFromJson(parsed);
+      if (text) {
+        return text;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  // Case 3: JSONL stream - concatenate streaming deltas (Codex's
+  // agent_message_delta events, Cursor's stream-partial-output deltas).
+  const deltas: string[] = [];
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine.startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(trimmedLine);
+      const delta = extractDeltaFromJson(parsed);
+      if (delta) {
+        deltas.push(delta);
+      }
+    } catch {
+      continue;
+    }
+  }
+  if (deltas.length > 0) {
+    return deltas.join("");
+  }
+
+  // Case 4: raw text fallback - return the original stdout untouched so
+  // that the marker line scan can still match plain text output.
+  return rawOutput;
+}
+
+// Look up a final assistant message inside a single parsed JSON value.
+// Covers the field names emitted by all three supported CLIs.
+function extractMessageFromJson(value: unknown): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const obj = value as Record<string, unknown>;
+
+  // Claude --print / Cursor --output-format json: top-level "result" string
+  if (typeof obj.result === "string") {
+    return obj.result;
+  }
+
+  // Codex JSONL: task_complete event carries the final natural-language reply
+  if (typeof obj.last_agent_message === "string") {
+    return obj.last_agent_message;
+  }
+
+  // Codex JSONL: agent_message event carries the assistant text directly
+  if (typeof obj.message === "string") {
+    return obj.message;
+  }
+
+  // Cursor stream-json: assistant turn with content blocks
+  // { "type": "assistant", "message": { "content": [{ "text": "..." }] } }
+  const message = obj.message;
+  if (message && typeof message === "object") {
+    const content = (message as { content?: unknown }).content;
+    if (Array.isArray(content)) {
+      const texts: string[] = [];
+      for (const part of content) {
+        if (
+          part &&
+          typeof part === "object" &&
+          typeof (part as { text?: unknown }).text === "string"
+        ) {
+          texts.push((part as { text: string }).text);
+        }
+      }
+      if (texts.length > 0) {
+        return texts.join("");
+      }
+    }
+  }
+
+  return null;
+}
+
+// Extract a streaming delta from a parsed JSONL event. Used to reconstruct
+// the final assistant message from incremental tokens when no single
+// terminating event is available.
+function extractDeltaFromJson(value: unknown): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.delta === "string") {
+    return obj.delta;
+  }
+  return null;
+}
+
+// Pull the single COMMIT_MSG: <summary> line out of the assistant text.
+// The marker is searched bottom-up so a model that emits multiple drafts
+// is interpreted as choosing the last one.
+export function parseCommitMessage(rawOutput: string): string | null {
+  const textToSearch = extractSearchableText(rawOutput);
+
+  const lines = textToSearch.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line.startsWith(COMMIT_MSG_PREFIX)) {
+      const message = line.substring(COMMIT_MSG_PREFIX.length).trim();
+      if (message.length > 0) {
+        return message;
+      }
+    }
+  }
+
+  return null;
+}
+
+// Pull every FIX_DETAIL: <bug_id> | <description> line out of the
+// assistant text into a Map keyed by bug ID. Lines without the "|"
+// separator or with empty fields are silently ignored.
+export function parseFixDetails(rawOutput: string): Map<string, string> {
+  const details = new Map<string, string>();
+  const textToSearch = extractSearchableText(rawOutput);
+
+  for (const line of textToSearch.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith(FIX_DETAIL_PREFIX)) {
+      continue;
+    }
+
+    const content = trimmed.substring(FIX_DETAIL_PREFIX.length).trim();
+    const separatorIndex = content.indexOf("|");
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    const bugId = content.substring(0, separatorIndex).trim();
+    const fixDescription = content.substring(separatorIndex + 1).trim();
+    if (bugId && fixDescription) {
+      details.set(bugId, fixDescription);
+    }
+  }
+
+  return details;
+}

--- a/src/fixers/outputParser.ts
+++ b/src/fixers/outputParser.ts
@@ -103,6 +103,24 @@ function extractMessageFromJson(value: unknown): string | null {
     return obj.message;
   }
 
+  // Codex JSONL (current `codex exec --json`): the final reply arrives on an
+  // item.completed event whose nested item is an agent_message carrying the
+  // text. Example:
+  //   { "type": "item.completed",
+  //     "item": { "type": "agent_message", "text": "..." } }
+  // turn.completed events are usually usage-only and carry no reply text.
+  const item = obj.item;
+  if (item && typeof item === "object") {
+    const itemObj = item as Record<string, unknown>;
+    if (
+      itemObj.type === "agent_message" &&
+      typeof itemObj.text === "string" &&
+      itemObj.text.length > 0
+    ) {
+      return itemObj.text;
+    }
+  }
+
   // Cursor stream-json: assistant turn with content blocks
   // { "type": "assistant", "message": { "content": [{ "text": "..." }] } }
   const message = obj.message;

--- a/src/fixers/spawnRunner.ts
+++ b/src/fixers/spawnRunner.ts
@@ -1,0 +1,134 @@
+// Shared child-process runner for BugFixer implementations.
+// Spawns a CLI with the given binary/args, pipes the prompt via stdin,
+// applies a hard wall-clock timeout (SIGTERM then SIGKILL after a grace
+// period), captures bounded stdout/stderr buffers, and resolves with the
+// captured stdout on success.
+// Limitations: stderr is retained only for diagnostic logging on failure.
+//   stdout is truncated to maxStdoutSize bytes (keeping the tail) so a
+//   runaway model cannot exhaust process memory.
+
+import { spawn } from "child_process";
+
+import { logger } from "../logger.js";
+
+// Time the runner waits between SIGTERM and the follow-up SIGKILL when
+// the child does not exit gracefully on the first signal.
+const SIGKILL_GRACE_MS = 5_000;
+
+// Configuration for a single child-process invocation.
+export interface SpawnFixerOptions {
+  // Executable to spawn, e.g. "claude" / "agent" / "codex".
+  binary: string;
+  // Argument vector passed verbatim to the child process.
+  args: string[];
+  // Working directory of the child process (typically the cloned repo).
+  cwd: string;
+  // Text written to the child's stdin, then stdin is closed.
+  stdinInput: string;
+  // Hard wall-clock timeout. The runner sends SIGTERM at this point and
+  // falls back to SIGKILL after SIGKILL_GRACE_MS.
+  timeoutMs: number;
+  // Human-readable name used in log messages and error strings.
+  logTag: string;
+  // Maximum number of bytes of stdout to keep (the tail is preserved).
+  maxStdoutSize: number;
+  // Extra environment variables merged on top of process.env. Each fixer
+  // can use this to inject CLI-specific knobs without polluting the
+  // daemon's own environment.
+  env?: Record<string, string>;
+}
+
+// Run the configured child process and resolve with the captured stdout.
+// Rejects with a descriptive Error on timeout, non-zero exit, or spawn
+// failure.
+export function runFixerProcess(opts: SpawnFixerOptions): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let settled = false;
+
+    const child = spawn(opts.binary, opts.args, {
+      cwd: opts.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: opts.env ? { ...process.env, ...opts.env } : process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    const killTimer = setTimeout(() => {
+      if (settled) return;
+      logger.warn(`${opts.logTag} timed out, sending SIGTERM.`, {
+        timeoutMs: opts.timeoutMs,
+      });
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (settled) return;
+        logger.warn(
+          `${opts.logTag} did not exit after SIGTERM, sending SIGKILL.`
+        );
+        child.kill("SIGKILL");
+      }, SIGKILL_GRACE_MS);
+    }, opts.timeoutMs);
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+      if (stdout.length > opts.maxStdoutSize) {
+        stdout = stdout.substring(stdout.length - opts.maxStdoutSize);
+      }
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("close", (code, signal) => {
+      clearTimeout(killTimer);
+      if (settled) return;
+      settled = true;
+
+      if (signal === "SIGTERM" || signal === "SIGKILL") {
+        logger.error(`${opts.logTag} timed out.`, {
+          signal,
+          timeoutMs: opts.timeoutMs,
+          stderr: stderr.substring(0, 1000) || "(empty)",
+          stdoutTail:
+            stdout.substring(Math.max(0, stdout.length - 1000)) || "(empty)",
+        });
+        reject(
+          new Error(
+            `${opts.logTag} fix generation timed out after ${
+              opts.timeoutMs / 1000
+            }s.`
+          )
+        );
+        return;
+      }
+
+      if (code !== 0) {
+        logger.error(`${opts.logTag} exited with non-zero code.`, {
+          exitCode: code,
+          stderr: stderr.substring(0, 1000) || "(empty)",
+          stdoutTail:
+            stdout.substring(Math.max(0, stdout.length - 2000)) || "(empty)",
+        });
+        reject(
+          new Error(`${opts.logTag} fix generation exited with code ${code}.`)
+        );
+        return;
+      }
+
+      resolve(stdout);
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(killTimer);
+      if (settled) return;
+      settled = true;
+      reject(
+        new Error(`${opts.logTag} fix generation failed: ${error.message}`)
+      );
+    });
+
+    child.stdin.write(opts.stdinInput);
+    child.stdin.end();
+  });
+}

--- a/src/fixers/types.ts
+++ b/src/fixers/types.ts
@@ -1,0 +1,40 @@
+// Shared types for the pluggable bug-fixing backend (BugFixer).
+// A BugFixer wraps one specific CLI (claude / codex / cursor) and
+// is responsible for executing the underlying tool against a cloned
+// repository with the prepared prompt, then returning the raw textual
+// output that the common output parser can interpret.
+// Limitations: This interface intentionally hides per-CLI flags and
+//   authentication concerns from the rest of Fixooly. The output format
+//   must contain COMMIT_MSG: and FIX_DETAIL: marker lines somewhere in
+//   the captured stdout for parseCommitMessage/parseFixDetails to work.
+
+import type { FixerKind } from "../types.js";
+
+export type { FixerKind };
+
+// Input passed to a BugFixer for a single fix generation invocation.
+export interface FixerInput {
+  // Absolute path to the cloned repository checked out on the PR branch.
+  cwd: string;
+  // Fully built prompt (bug list, project context, instructions).
+  prompt: string;
+  // Maximum wall-clock time the underlying CLI is allowed to run.
+  timeoutMs: number;
+  // Number of bugs being fixed in this invocation. Used for logging only.
+  bugCount: number;
+}
+
+// Common contract every fixer implementation must satisfy.
+export interface BugFixer {
+  // Stable identifier of the backend, used for logs and config validation.
+  readonly name: FixerKind;
+  // Verifies that the CLI binary is installed and authentication is set
+  // up before the daemon enters its polling loop. Should throw a clearly
+  // worded Error when any required piece is missing.
+  verifyPrerequisites(): Promise<void>;
+  // Executes the fix generation. Implementations spawn the child CLI,
+  // pipe the prompt through stdin, and return whatever was written to
+  // stdout so the shared parser can extract the COMMIT_MSG / FIX_DETAIL
+  // marker lines.
+  generateFix(input: FixerInput): Promise<string>;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,20 @@
 // Main entry point for Fixooly daemon.
 // Orchestrates the polling loop: discovers Cursor Bugbot reports
-// on open PRs, generates fixes using Claude Code, and commits
-// the fixes directly to the PR head branch.
-// Uses GitHub App authentication; monitored repositories are auto-discovered
-// from App installations.
-// Limitations: Single-threaded; processes PRs sequentially
-//   within each polling cycle. Graceful shutdown on SIGINT/SIGTERM.
+// on open PRs, generates fixes using the configured BugFixer backend
+// (Claude / Codex / Cursor CLI), and commits the fixes directly to the
+// PR head branch.
+// Uses GitHub App authentication; monitored repositories are
+// auto-discovered from App installations.
+// Limitations: Single-threaded; processes PRs sequentially within each
+//   polling cycle. Graceful shutdown on SIGINT/SIGTERM.
 
 import { mkdirSync, openSync, closeSync, unlinkSync, writeFileSync, readFileSync } from "fs";
 import { dirname, join } from "path";
 
 import { BugbotMonitor } from "./bugbotMonitor.js";
 import { loadConfig } from "./config.js";
+import { createFixer } from "./fixers/factory.js";
+import type { BugFixer } from "./fixers/types.js";
 import { FixGenerator } from "./fixGenerator.js";
 import { GitHubClient } from "./githubClient.js";
 import { logger, setLogLevel } from "./logger.js";
@@ -26,13 +29,15 @@ class FixoolyDaemon {
   private state: StateStore;
   private github!: GitHubClient;
   private monitor!: BugbotMonitor;
+  private fixer: BugFixer;
   private fixGenerator: FixGenerator;
   private isShuttingDown = false;
 
   constructor(config: Config) {
     this.config = config;
     this.state = new StateStore(config.dbPath);
-    this.fixGenerator = new FixGenerator(config);
+    this.fixer = createFixer(config);
+    this.fixGenerator = new FixGenerator(config, this.fixer);
   }
 
   // ============================================================
@@ -44,7 +49,8 @@ class FixoolyDaemon {
     logger.info("Configuration loaded.", {
       appId: this.config.appId,
       pollInterval: this.config.pollInterval,
-      claudeModel: this.config.claudeModel ?? "(default)",
+      fixer: this.fixer.name,
+      model: this.selectedModel() ?? "(default)",
     });
 
     await this.verifyPrerequisites();
@@ -60,6 +66,21 @@ class FixoolyDaemon {
     this.monitor = new BugbotMonitor(this.github, this.state, this.config);
 
     logger.info("Initialization complete. Starting daemon loop.");
+  }
+
+  // Resolve the model override that applies to the currently selected
+  // fixer, used only for the human-friendly startup log line.
+  private selectedModel(): string | null {
+    switch (this.fixer.name) {
+      case "claude":
+        return this.config.claudeModel;
+      case "codex":
+        return this.config.codexModel;
+      case "cursor":
+        return this.config.cursorModel;
+      default:
+        return null;
+    }
   }
 
   // ============================================================
@@ -82,30 +103,10 @@ class FixoolyDaemon {
       appId: this.config.appId,
     });
 
-    try {
-      const { stdout } = await execFileAsync("claude", ["--version"]);
-      logger.debug("claude CLI version.", { version: stdout.trim() });
-    } catch {
-      throw new Error(
-        "claude CLI is not available. Install Claude Code first: https://docs.anthropic.com/en/docs/claude-code"
-      );
-    }
-
-    if (
-      !process.env.CLAUDE_CODE_OAUTH_TOKEN &&
-      !process.env.ANTHROPIC_API_KEY
-    ) {
-      const { existsSync } = await import("fs");
-      const homeDir = process.env.HOME ?? "/root";
-      const credFile = `${homeDir}/.claude/.credentials.json`;
-      if (!existsSync(credFile)) {
-        logger.warn(
-          "No Claude authentication detected. " +
-          "On macOS Docker, set CLAUDE_CODE_OAUTH_TOKEN (run 'claude setup-token' to generate). " +
-          "On Linux, ensure ~/.claude is mounted and contains .credentials.json."
-        );
-      }
-    }
+    // Backend-specific CLI / credential checks. Each BugFixer is
+    // responsible for verifying that its own binary is reachable and
+    // that authentication is set up.
+    await this.fixer.verifyPrerequisites();
 
     try {
       await execFileAsync("git", ["--version"]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,11 @@
 // Configuration
 // ============================================================
 
+// Selects which bug-fix backend the daemon dispatches to. The actual
+// CLI invocation, authentication, and prompt-shape conventions live in
+// the corresponding BugFixer implementation under src/fixers/.
+export type FixerKind = "claude" | "codex" | "cursor";
+
 export interface Config {
   appId: number;
   privateKey: string;
@@ -15,7 +20,10 @@ export interface Config {
   pollInterval: number;
   workDir: string;
   dbPath: string;
+  fixer: FixerKind;
   claudeModel: string | null;
+  codexModel: string | null;
+  cursorModel: string | null;
   logLevel: LogLevel;
 }
 


### PR DESCRIPTION
## Summary

- Abstract the fix backend behind a `BugFixer` interface so Fixooly can dispatch to **Claude CLI**, **OpenAI Codex CLI**, or **Cursor CLI** depending on the new required `AUTOFIX_FIXER` environment variable.
- Cursor is the recommended default for daemon use because the Cursor Pro Auto+Composer pool has no 5-hour rolling rate limit, unlike Codex on ChatGPT Plus/Pro. The plan in `.plans/multi-backend-fixer.plan.md` walks through the comparison.
- Centralise child-process plumbing (timeout, stdin, bounded stdout) in `src/fixers/spawnRunner.ts` and the `COMMIT_MSG:` / `FIX_DETAIL:` marker parsing in `src/fixers/outputParser.ts`. The parser now also understands Cursor's JSON output and Codex's JSONL event stream.
- `FixGenerator` keeps the cloning / commit / push responsibilities and receives the active `BugFixer` via constructor injection. `main.ts` instantiates the right fixer through `createFixer()` and delegates `verifyPrerequisites()` to the backend itself.

## Files

- New: `src/fixers/{types,factory,claudeFixer,codexFixer,cursorFixer,spawnRunner,outputParser}.ts`
- Modified: `src/types.ts`, `src/config.ts`, `src/fixGenerator.ts`, `src/main.ts`
- Docs: `README.md`, `.env.example`, `CLAUDE.md`, `AGENTS.md`

## Test plan

- [x] `npm run typecheck` -- zero errors
- [x] `npm run build` -- `dist/` produced without errors
- [ ] Smoke test with `AUTOFIX_FIXER=cursor` against a real PR (deferred until the new Cursor Pro account is provisioned)
- [ ] Smoke test with `AUTOFIX_FIXER=codex` against a real PR (deferred until ChatGPT Plus is provisioned)
- [ ] Regression test with `AUTOFIX_FIXER=claude` against the existing setup (manual run on the daemon host)

## Out of scope

- Live runtime testing of the Cursor / Codex backends (will be validated by the user after subscriptions are provisioned).
- Automatic fallback between backends when one is rate-limited.

Closes #11

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking config (mandatory AUTOFIX_FIXER) and new untested CLI integrations change how fixes are applied and committed to PR branches; misconfiguration or parser/CLI mismatches could fail silently or produce bad commits.
> 
> **Overview**
> This PR **replaces the hard-coded Claude `claude -p` path** with a pluggable **`BugFixer`** layer so the daemon can run fixes through **Cursor**, **Codex**, or **Claude** CLIs.
> 
> **Configuration:** **`AUTOFIX_FIXER`** is now **required** (no default)—`claude` / `codex` / `cursor`—with optional per-backend model overrides (`AUTOFIX_CURSOR_MODEL`, `AUTOFIX_CODEX_MODEL`, `AUTOFIX_CLAUDE_MODEL`) and documented API keys in **`.env.example`**. Existing deployments must set **`AUTOFIX_FIXER`** explicitly (e.g. `claude` to keep prior behavior).
> 
> **Code:** New **`src/fixers/`** modules (`types`, `factory`, three fixer implementations, **`spawnRunner`**, **`outputParser`**) own CLI invocation, timeouts, and parsing of **`COMMIT_MSG:`** / **`FIX_DETAIL:`** across plain text, JSON, and JSONL. **`FixGenerator`** only clones, builds the prompt, calls **`fixer.generateFix`**, then commits/pushes; **`main.ts`** wires **`createFixer(config)`** and delegates prerequisite checks to the selected backend.
> 
> **Docs:** **README**, **AGENTS.md**, **CLAUDE.md**, and a plan file describe backend selection (Cursor recommended for daemons) and the updated architecture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6729e01cb4c70112cb53c0750b75c07f074e61cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->